### PR TITLE
Sync index_created times on indices; add unix_timestamp field

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bulk-data-service"
-version = "0.2.0"
+version = "0.2.1"
 requires-python = ">= 3.12.6"
 readme = "README.md"
 dependencies = [

--- a/src/bulk_data_service/dataset_indexing.py
+++ b/src/bulk_data_service/dataset_indexing.py
@@ -77,7 +77,7 @@ def create_reporting_org_index_json(
 
 
 def create_index_time_entries(created_time: datetime) -> dict[str, Any]:
-    return {"index_created": created_time, "index_created_epoch": int(created_time.timestamp())}
+    return {"index_created": created_time, "index_created_unix_timestamp": int(created_time.timestamp())}
 
 
 def get_reporting_orgs_for_datasets(

--- a/src/bulk_data_service/dataset_indexing.py
+++ b/src/bulk_data_service/dataset_indexing.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from datetime import datetime
 from typing import Any
 
 from azure.storage.blob import BlobServiceClient
@@ -11,14 +12,17 @@ from utilities.misc import get_timestamp
 def create_and_upload_indices(
     context: dict, datasets_in_bds: dict[uuid.UUID, dict], reporting_orgs_in_bds: dict[uuid.UUID, dict]
 ):
+    index_creation_time = get_timestamp()
 
     context["logger"].info("Creating indices")
 
-    dataset_index_minimal = create_dataset_index_json(context, datasets_in_bds, reporting_orgs_in_bds, "minimal")
+    dataset_index_minimal = create_dataset_index_json(context, index_creation_time, datasets_in_bds, "minimal")
 
-    dataset_index_full = create_dataset_index_json(context, datasets_in_bds, reporting_orgs_in_bds, "full")
+    dataset_index_full = create_dataset_index_json(context, index_creation_time, datasets_in_bds, "full")
 
-    reporting_org_index_full = create_reporting_org_index_json(context, datasets_in_bds, reporting_orgs_in_bds)
+    reporting_org_index_full = create_reporting_org_index_json(
+        context, index_creation_time, datasets_in_bds, reporting_orgs_in_bds
+    )
 
     upload_index_json_to_azure(context, get_dataset_index_name(context, "minimal"), dataset_index_minimal)
 
@@ -46,12 +50,12 @@ def upload_index_json_to_azure(context: dict, index_name: str, index_json: str):
 
 def create_dataset_index_json(
     context: dict,
+    created_time: datetime,
     datasets_in_bds: dict[uuid.UUID, dict],
-    reporting_orgs_in_bds: dict[uuid.UUID, dict],
     index_type: str,
 ) -> str:
 
-    index = {"index_created": get_timestamp(), "datasets": []}
+    index = create_index_time_entries(created_time)
 
     index["datasets"] = get_dataset_index(context, datasets_in_bds, index_type)
 
@@ -59,14 +63,21 @@ def create_dataset_index_json(
 
 
 def create_reporting_org_index_json(
-    context: dict, datasets_in_bds: dict[uuid.UUID, dict], reporting_orgs_in_bds: dict[uuid.UUID, dict]
+    context: dict,
+    created_time: datetime,
+    datasets_in_bds: dict[uuid.UUID, dict],
+    reporting_orgs_in_bds: dict[uuid.UUID, dict],
 ) -> str:
 
-    index = {"index_created": get_timestamp(), "reporting_orgs": []}
+    index = create_index_time_entries(created_time)
 
     index["reporting_orgs"] = get_reporting_orgs_for_datasets(context, datasets_in_bds, reporting_orgs_in_bds)
 
     return json.dumps(index, default=str, sort_keys=True, indent=True)
+
+
+def create_index_time_entries(created_time: datetime) -> dict[str, Any]:
+    return {"index_created": created_time, "index_created_epoch": int(created_time.timestamp())}
 
 
 def get_reporting_orgs_for_datasets(

--- a/tests/integration/test_dataset_indexing.py
+++ b/tests/integration/test_dataset_indexing.py
@@ -91,14 +91,14 @@ def test_index_created_field_is_generated_dataset_indices(get_and_clear_up_conte
     minimal_index = json.loads(minimal_index_blob.download_blob().readall())
 
     assert minimal_index["index_created"] is not None
-    assert minimal_index["index_created_epoch"] is not None
+    assert minimal_index["index_created_unix_timestamp"] is not None
 
     full_index_name = get_dataset_index_name(context, "full")
     full_index_blob = blob_service_client.get_blob_client(zip_container_name, full_index_name)
     full_index = json.loads(full_index_blob.download_blob().readall())
 
     assert full_index["index_created"] is not None
-    assert full_index["index_created_epoch"] is not None
+    assert full_index["index_created_unix_timestamp"] is not None
 
     blob_service_client.close()
 
@@ -119,7 +119,7 @@ def test_index_created_field_is_generated_reporting_org_index(get_and_clear_up_c
     reporting_org_index = json.loads(reporting_org_index_blob.download_blob().readall())
 
     assert reporting_org_index["index_created"] is not None
-    assert reporting_org_index["index_created_epoch"] is not None
+    assert reporting_org_index["index_created_unix_timestamp"] is not None
 
     blob_service_client.close()
 
@@ -143,7 +143,7 @@ def test_index_created_fields_in_dataset_indices_have_same_value(get_and_clear_u
     full_index_blob = blob_service_client.get_blob_client(zip_container_name, full_index_name)
     full_index = json.loads(full_index_blob.download_blob().readall())
 
-    assert minimal_index["index_created_epoch"] == full_index["index_created_epoch"]
+    assert minimal_index["index_created_unix_timestamp"] == full_index["index_created_unix_timestamp"]
 
     blob_service_client.close()
 
@@ -167,7 +167,7 @@ def test_index_created_fields_in_dataset_reporting_org_indices_have_same_value(g
     reporting_org_index_blob = blob_service_client.get_blob_client(zip_container_name, reporting_org_index_name)
     reporting_org_index = json.loads(reporting_org_index_blob.download_blob().readall())
 
-    assert minimal_index["index_created_epoch"] == reporting_org_index["index_created_epoch"]
+    assert minimal_index["index_created_unix_timestamp"] == reporting_org_index["index_created_unix_timestamp"]
 
     blob_service_client.close()
 

--- a/tests/integration/test_dataset_indexing.py
+++ b/tests/integration/test_dataset_indexing.py
@@ -75,6 +75,103 @@ def test_creation_of_dataset_entry_in_minimal_index_when_download_success(get_an
     blob_service_client.close()
 
 
+def test_index_created_field_is_generated_dataset_indices(get_and_clear_up_context):  # noqa: F811
+    context = get_and_clear_up_context
+
+    context["DATA_REGISTRY_BASE_URL"] = "http://localhost:3000/registration/datasets-01"
+    datasets_in_bds = {}
+    checker_run(context, datasets_in_bds)
+
+    blob_service_client = BlobServiceClient.from_connection_string(context["AZURE_STORAGE_CONNECTION_STRING"])
+
+    zip_container_name = get_azure_container_name(context, "zip")
+
+    minimal_index_name = get_dataset_index_name(context, "minimal")
+    minimal_index_blob = blob_service_client.get_blob_client(zip_container_name, minimal_index_name)
+    minimal_index = json.loads(minimal_index_blob.download_blob().readall())
+
+    assert minimal_index["index_created"] is not None
+    assert minimal_index["index_created_epoch"] is not None
+
+    full_index_name = get_dataset_index_name(context, "full")
+    full_index_blob = blob_service_client.get_blob_client(zip_container_name, full_index_name)
+    full_index = json.loads(full_index_blob.download_blob().readall())
+
+    assert full_index["index_created"] is not None
+    assert full_index["index_created_epoch"] is not None
+
+    blob_service_client.close()
+
+
+def test_index_created_field_is_generated_reporting_org_index(get_and_clear_up_context):  # noqa: F811
+    context = get_and_clear_up_context
+
+    context["DATA_REGISTRY_BASE_URL"] = "http://localhost:3000/registration/datasets-01"
+    datasets_in_bds = {}
+    checker_run(context, datasets_in_bds)
+
+    blob_service_client = BlobServiceClient.from_connection_string(context["AZURE_STORAGE_CONNECTION_STRING"])
+
+    zip_container_name = get_azure_container_name(context, "zip")
+
+    reporting_org_index_name = get_reporting_org_index_name(context)
+    reporting_org_index_blob = blob_service_client.get_blob_client(zip_container_name, reporting_org_index_name)
+    reporting_org_index = json.loads(reporting_org_index_blob.download_blob().readall())
+
+    assert reporting_org_index["index_created"] is not None
+    assert reporting_org_index["index_created_epoch"] is not None
+
+    blob_service_client.close()
+
+
+def test_index_created_fields_in_dataset_indices_have_same_value(get_and_clear_up_context):  # noqa: F811
+    context = get_and_clear_up_context
+
+    context["DATA_REGISTRY_BASE_URL"] = "http://localhost:3000/registration/datasets-01"
+    datasets_in_bds = {}
+    checker_run(context, datasets_in_bds)
+
+    blob_service_client = BlobServiceClient.from_connection_string(context["AZURE_STORAGE_CONNECTION_STRING"])
+
+    zip_container_name = get_azure_container_name(context, "zip")
+
+    minimal_index_name = get_dataset_index_name(context, "minimal")
+    minimal_index_blob = blob_service_client.get_blob_client(zip_container_name, minimal_index_name)
+    minimal_index = json.loads(minimal_index_blob.download_blob().readall())
+
+    full_index_name = get_dataset_index_name(context, "full")
+    full_index_blob = blob_service_client.get_blob_client(zip_container_name, full_index_name)
+    full_index = json.loads(full_index_blob.download_blob().readall())
+
+    assert minimal_index["index_created_epoch"] == full_index["index_created_epoch"]
+
+    blob_service_client.close()
+
+
+def test_index_created_fields_in_dataset_reporting_org_indices_have_same_value(get_and_clear_up_context):  # noqa: F811
+    context = get_and_clear_up_context
+
+    context["DATA_REGISTRY_BASE_URL"] = "http://localhost:3000/registration/datasets-01"
+    datasets_in_bds = {}
+    checker_run(context, datasets_in_bds)
+
+    blob_service_client = BlobServiceClient.from_connection_string(context["AZURE_STORAGE_CONNECTION_STRING"])
+
+    zip_container_name = get_azure_container_name(context, "zip")
+
+    minimal_index_name = get_dataset_index_name(context, "minimal")
+    minimal_index_blob = blob_service_client.get_blob_client(zip_container_name, minimal_index_name)
+    minimal_index = json.loads(minimal_index_blob.download_blob().readall())
+
+    reporting_org_index_name = get_reporting_org_index_name(context)
+    reporting_org_index_blob = blob_service_client.get_blob_client(zip_container_name, reporting_org_index_name)
+    reporting_org_index = json.loads(reporting_org_index_blob.download_blob().readall())
+
+    assert minimal_index["index_created_epoch"] == reporting_org_index["index_created_epoch"]
+
+    blob_service_client.close()
+
+
 def test_create_reporting_org_entry_in_minimal_index_for_download_success(get_and_clear_up_context):  # noqa: F811
     context = get_and_clear_up_context
 


### PR DESCRIPTION
This change makes it so that the `index_created` field on all the indices is set to the same value for each run. This will allow clients (such as the Unified Pipeline) to ensure that they are using dataset and reporting_org indices from the same run of the Bulk Data Service. 

In addition, this update adds a new field, index_created_epoch, which is the created field as a Unix epoch. This provides convenience for some consumers, and also allows us to extract this field for Prometheus using the JSON exporter.