### PR TITLE
build: downgrade specs

### DIFF
--- a/azure-deployment/azure-resource-manager-deployment-template.yml
+++ b/azure-deployment/azure-resource-manager-deployment-template.yml
@@ -17,8 +17,8 @@ properties: # Properties of container group
       properties: # Properties of an instance
         resources: # Resource requirements of the instance
           requests:
-            memoryInGB: 12
-            cpu: 3
+            memoryInGB: 6
+            cpu: 1.5
         image: "#ACR_LOGIN_SERVER#/#APP_NAME#-#TARGET_ENVIRONMENT#:#DOCKER_IMAGE_TAG#"
         ports:
           - port: 9090


### PR DESCRIPTION
I ran an experiment to see if tripling the resources of the container would help address #52; there was some speed up, but not enough to justify threefold cost increase. Downgrading to 1.5 CPU and 6 Gb RAM to test speed on those specs for a bit.