### PR TITLE
develop->main - blank out existing HTTP Status when download fails without an HTTP response

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bulk-data-service"
-version = "1.1.3"
+version = "1.1.4"
 requires-python = ">= 3.12.6"
 readme = "README.md"
 dependencies = [

--- a/src/bulk_data_service/dataset_updater.py
+++ b/src/bulk_data_service/dataset_updater.py
@@ -140,6 +140,7 @@ def add_or_update_registered_dataset(
             insert_or_update_dataset(db_conn, bds_dataset)
         except Exception as e:
             bds_dataset["most_recent_get_attempt_datetime"] = get_timestamp()
+            bds_dataset["most_recent_get_attempt_http_status"] = None
             bds_dataset["most_recent_get_attempt_error_details"] = json.dumps(
                 {
                     "message": "Download of IATI XML produced EXCEPTION with GET request",

--- a/src/bulk_data_service/zippers.py
+++ b/src/bulk_data_service/zippers.py
@@ -10,7 +10,6 @@ from bulk_data_service.dataset_indexing import get_dataset_index_name, get_repor
 from utilities.azure import azure_download_blob, get_azure_container_name, upload_zip_to_azure
 from utilities.misc import (
     dataset_has_iati_xml_download,
-    filter_dict_by_structure,
     get_number_xml_files_in_dir,
     get_timestamp_as_str_z,
     lookup_licence_title_from_id,


### PR DESCRIPTION
Previously when a download failed without an HTTP response, there was one field, the `http_status`, that was not being blanked out. Resolves https://github.com/IATI/bulk-data-service/issues/79