### PR TITLE
Improve app configuration by replacing context `dict` with custom config class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bulk-data-service"
-version = "1.1.6"
+version = "1.1.7"
 requires-python = ">= 3.12.6"
 readme = "README.md"
 dependencies = [

--- a/src/bulk_data_service/checker.py
+++ b/src/bulk_data_service/checker.py
@@ -8,19 +8,20 @@ from bulk_data_service.dataset_remover import remove_deleted_datasets_from_bds, 
 from bulk_data_service.dataset_updater import add_or_update_datasets
 from bulk_data_service.reporting_org_sync import add_or_update_reporting_orgs, remove_deleted_reporting_orgs_from_bds
 from bulk_data_service.zipper import zipper_run
+from config.bds_context import BDSContext
 from dataset_registration.iati_registry_ckan import fetch_datasets_metadata, fetch_reporting_orgs_metadata
 from utilities.db import get_datasets_in_bds, get_reporting_orgs_in_bds
 from utilities.prometheus import get_prom_metric, update_metrics_from_db, update_prom_metric
 
 
-def checker(context: dict):
+def checker(context: BDSContext):
     if context["single_run"]:
         checker_run(context, get_datasets_in_bds(context))
     else:
         checker_service_loop(context)
 
 
-def checker_service_loop(context: dict):
+def checker_service_loop(context: BDSContext):
 
     datasets_in_zip = {}  # type: dict[uuid.UUID, dict]
     datasets_in_bds = get_datasets_in_bds(context)
@@ -31,26 +32,26 @@ def checker_service_loop(context: dict):
 
             zipper_run(context, datasets_in_zip, datasets_in_bds, get_reporting_orgs_in_bds(context))
 
-            context["logger"].info("Pausing for {} mins".format(context["CHECKER_LOOP_WAIT_MINS"]))
+            context.logger.info("Pausing for {} mins".format(context["CHECKER_LOOP_WAIT_MINS"]))
             time.sleep(60 * int(context["CHECKER_LOOP_WAIT_MINS"]))
 
         except Exception as e:
-            context["logger"].error(
+            context.logger.error(
                 "Exception in checker service loop. "
                 "Waiting 10 minutes then restarting. "
                 "Exception message: {}".format(e).replace("\n", "")
             )
-            context["logger"].error("Full traceback: " "{}".format(traceback.format_exc()))
+            context.logger.error("Full traceback: " "{}".format(traceback.format_exc()))
 
             get_prom_metric(context, "number_crashes").inc()
 
             time.sleep(60 * 10)
 
 
-def checker_run(context: dict, datasets_in_bds: dict[uuid.UUID, dict]):
+def checker_run(context: BDSContext, datasets_in_bds: dict[uuid.UUID, dict]):
     run_start = datetime.datetime.now(datetime.UTC)
 
-    context["logger"].info("Checker starting run")
+    context.logger.info("Checker starting run")
 
     registered_reporting_orgs = fetch_reporting_orgs_metadata(context)
 
@@ -76,7 +77,7 @@ def checker_run(context: dict, datasets_in_bds: dict[uuid.UUID, dict]):
 
     update_prom_metric(context, "checker_run_duration", (run_end - run_start).seconds)
 
-    context["logger"].info(
+    context.logger.info(
         "Checker finished in {}. Datasets processed: {}. Seconds per dataset: {}".format(
             run_end - run_start,
             len(registered_datasets),

--- a/src/bulk_data_service/dataset_indexing.py
+++ b/src/bulk_data_service/dataset_indexing.py
@@ -5,14 +5,17 @@ from typing import Any
 
 from azure.storage.blob import BlobServiceClient
 
+from config.bds_context import BDSContext
 from utilities.azure import azure_upload_to_blob, get_azure_blob_public_url
 from utilities.misc import dataset_has_iati_xml_download, filter_dict_by_structure, get_timestamp
 
 
-def create_and_upload_indices(context: dict, datasets: dict[uuid.UUID, dict], reporting_orgs: dict[uuid.UUID, dict]):
+def create_and_upload_indices(
+    context: BDSContext, datasets: dict[uuid.UUID, dict], reporting_orgs: dict[uuid.UUID, dict]
+):
     index_creation_time = get_timestamp()
 
-    context["logger"].info("Creating indices")
+    context.logger.info("Creating indices")
 
     dataset_index_minimal = create_dataset_index_json(context, index_creation_time, datasets, "minimal")
 
@@ -26,10 +29,10 @@ def create_and_upload_indices(context: dict, datasets: dict[uuid.UUID, dict], re
 
     upload_index_json_to_azure(context, get_reporting_org_index_name(context), reporting_org_index)
 
-    context["logger"].info("Creation of indices finished")
+    context.logger.info("Creation of indices finished")
 
 
-def upload_index_json_to_azure(context: dict, index_name: str, index_json: str):
+def upload_index_json_to_azure(context: BDSContext, index_name: str, index_json: str):
 
     az_blob_service = BlobServiceClient.from_connection_string(context["AZURE_STORAGE_CONNECTION_STRING"])
 
@@ -41,7 +44,7 @@ def upload_index_json_to_azure(context: dict, index_name: str, index_json: str):
 
 
 def create_dataset_index_json(
-    context: dict,
+    context: BDSContext,
     created_time: datetime,
     datasets_in_bds: dict[uuid.UUID, dict],
     index_type: str,
@@ -55,7 +58,7 @@ def create_dataset_index_json(
 
 
 def create_reporting_org_index_json(
-    context: dict,
+    context: BDSContext,
     created_time: datetime,
     datasets_in_bds: dict[uuid.UUID, dict],
     reporting_orgs_in_bds: dict[uuid.UUID, dict],
@@ -73,7 +76,7 @@ def create_index_created_entries(created_time: datetime) -> dict[str, Any]:
 
 
 def get_reporting_orgs_for_datasets(
-    context: dict, datasets: dict[uuid.UUID, dict], reporting_orgs: dict[uuid.UUID, dict]
+    context: BDSContext, datasets: dict[uuid.UUID, dict], reporting_orgs: dict[uuid.UUID, dict]
 ) -> list:
     reporting_org_names_w_datasets = set([dataset["reporting_org_short_name"] for dataset in datasets.values()])
 
@@ -91,11 +94,11 @@ def get_reporting_orgs_for_datasets(
     return orgs_w_datasets
 
 
-def get_index_all_datasets(context: dict, datasets: dict[uuid.UUID, dict], index_type: str) -> list:
+def get_index_all_datasets(context: BDSContext, datasets: dict[uuid.UUID, dict], index_type: str) -> list:
     return [get_dataset_index_entry(context, dataset, index_type) for _, dataset in datasets.items()]
 
 
-def get_dataset_index_entry(context: dict, dataset: dict, index_type: str) -> dict[str, Any]:
+def get_dataset_index_entry(context: BDSContext, dataset: dict, index_type: str) -> dict[str, Any]:
 
     minimal_index_structure = {
         "id": None,
@@ -123,22 +126,22 @@ def get_dataset_index_entry(context: dict, dataset: dict, index_type: str) -> di
     return index_entry
 
 
-def get_dataset_index_name(context: dict, index_type: str) -> str:
+def get_dataset_index_name(context: BDSContext, index_type: str) -> str:
     if index_type not in ["minimal", "full"]:
         raise ValueError("Unknown type for dataset index")
 
     return "datasets-{}".format(index_type)
 
 
-def get_reporting_org_index_name(context: dict) -> str:
+def get_reporting_org_index_name(context: BDSContext) -> str:
     return "reporting-orgs"
 
 
-def get_minimal_index_entry_from_dataset(context: dict, dataset: dict) -> dict:
+def get_minimal_index_entry_from_dataset(context: BDSContext, dataset: dict) -> dict:
     return get_full_index_entry_from_dataset(context, dataset)
 
 
-def get_full_index_entry_from_dataset(context: dict, dataset: dict) -> dict:
+def get_full_index_entry_from_dataset(context: BDSContext, dataset: dict) -> dict:
 
     index_field_structure = get_full_index_structured_fields(context)
 
@@ -163,7 +166,7 @@ def get_object_from_json_str(json_str: str | None):
     return json.loads(json_str if json_str is not None and json_str != "" else "{}")
 
 
-def get_full_index_structured_fields(context: dict) -> list[Any]:
+def get_full_index_structured_fields(context: BDSContext) -> list[Any]:
 
     def convert_to_object_from_json(dataset, db_field, index_prefix, index_field):
         return get_object_from_json_str(dataset[db_field])
@@ -223,7 +226,7 @@ def get_full_index_structured_fields(context: dict) -> list[Any]:
     ]
 
 
-def get_minimal_index_dataset_fields(context: dict) -> list[str]:
+def get_minimal_index_dataset_fields(context: BDSContext) -> list[str]:
     return [
         "id",
         "short_name",

--- a/src/bulk_data_service/dataset_remover.py
+++ b/src/bulk_data_service/dataset_remover.py
@@ -1,10 +1,10 @@
 import uuid
 from datetime import timedelta
-from typing import Any
 
 import psycopg
 from azure.storage.blob import BlobServiceClient
 
+from config.bds_context import BDSContext
 from utilities.azure import delete_azure_iati_blob
 from utilities.db import get_db_connection, insert_or_update_dataset, remove_dataset_from_db
 from utilities.misc import dataset_has_iati_xml_download, get_timestamp
@@ -12,7 +12,7 @@ from utilities.prometheus import update_prom_metric
 
 
 def remove_deleted_datasets_from_bds(
-    context: dict[str, Any], datasets_in_bds: dict[uuid.UUID, dict], registered_datasets: dict[uuid.UUID, dict]
+    context: BDSContext, datasets_in_bds: dict[uuid.UUID, dict], registered_datasets: dict[uuid.UUID, dict]
 ):
 
     db_conn = get_db_connection(context)
@@ -25,7 +25,7 @@ def remove_deleted_datasets_from_bds(
 
     for id in ids_to_delete:
 
-        context["logger"].info(
+        context.logger.info(
             "dataset id: {} - Dataset no longer exists in registration "
             "service so removing from Bulk Data Service".format(id)
         )
@@ -43,7 +43,7 @@ def remove_deleted_datasets_from_bds(
     db_conn.close()
 
 
-def remove_expired_downloads(context: dict[str, Any], datasets_in_bds: dict[uuid.UUID, dict]):
+def remove_expired_downloads(context: BDSContext, datasets_in_bds: dict[uuid.UUID, dict]):
 
     db_conn = get_db_connection(context)
 
@@ -64,12 +64,12 @@ def remove_expired_downloads(context: dict[str, Any], datasets_in_bds: dict[uuid
 
 
 def remove_download_for_expired_dataset(
-    context: dict[str, Any], db_conn: psycopg.Connection, az_blob_service: BlobServiceClient, bds_dataset: dict
+    context: BDSContext, db_conn: psycopg.Connection, az_blob_service: BlobServiceClient, bds_dataset: dict
 ) -> dict:
 
     max_hours = int(context["REMOVE_LAST_GOOD_DOWNLOAD_AFTER_FAILING_HOURS"])
 
-    context["logger"].info(
+    context.logger.info(
         "dataset id: {} - Last good download for dataset "
         "is over max threshold of {} hours, so removing "
         "last good download from Bulk Data Service".format(bds_dataset["id"], max_hours)
@@ -94,7 +94,7 @@ def remove_download_for_expired_dataset(
     return bds_dataset
 
 
-def dataset_has_download_and_is_expired(context: dict[str, Any], bds_dataset: dict) -> bool:
+def dataset_has_download_and_is_expired(context: BDSContext, bds_dataset: dict) -> bool:
 
     max_hours = int(context["REMOVE_LAST_GOOD_DOWNLOAD_AFTER_FAILING_HOURS"])
 

--- a/src/bulk_data_service/dataset_updater.py
+++ b/src/bulk_data_service/dataset_updater.py
@@ -10,6 +10,7 @@ import psycopg
 import requests
 from azure.storage.blob import BlobServiceClient
 
+from config.bds_context import BDSContext
 from utilities.azure import azure_blob_exists, azure_upload_to_blob
 from utilities.db import get_db_connection, insert_or_update_dataset
 from utilities.http import (
@@ -33,7 +34,7 @@ from utilities.prometheus import update_prom_metric
 
 
 def add_or_update_datasets(
-    context: dict, datasets_in_bds: dict[uuid.UUID, dict], registered_datasets: dict[uuid.UUID, dict]
+    context: BDSContext, datasets_in_bds: dict[uuid.UUID, dict], registered_datasets: dict[uuid.UUID, dict]
 ):
 
     update_prom_metric(context, "total_number_of_datasets", len(registered_datasets))
@@ -55,7 +56,7 @@ def add_or_update_datasets(
 
 
 def add_or_update_dataset_batch(
-    context: dict, datasets_in_bds: dict[uuid.UUID, dict], registered_datasets_to_update: dict[uuid.UUID, dict]
+    context: BDSContext, datasets_in_bds: dict[uuid.UUID, dict], registered_datasets_to_update: dict[uuid.UUID, dict]
 ):
 
     db_conn = get_db_connection(context)
@@ -84,7 +85,7 @@ def add_or_update_dataset_batch(
 
 
 def add_or_update_registered_dataset(
-    context: dict,
+    context: BDSContext,
     registered_dataset_id: uuid.UUID,
     datasets_in_bds: dict[uuid.UUID, dict],
     registered_datasets: dict[uuid.UUID, dict],
@@ -124,7 +125,7 @@ def add_or_update_registered_dataset(
 
             insert_or_update_dataset(db_conn, bds_dataset)
 
-            context["logger"].info("dataset id: {} - Added/updated dataset".format(bds_dataset["id"]))
+            context.logger.info("dataset id: {} - Added/updated dataset".format(bds_dataset["id"]))
 
         except RuntimeError as e:
             bds_dataset["most_recent_get_attempt_error_details"] = json.dumps(
@@ -136,7 +137,7 @@ def add_or_update_registered_dataset(
                     "http_headers": e.args[0]["http_headers"],
                 }
             )
-            context["logger"].warning(
+            context.logger.warning(
                 "dataset id: {} - {}".format(
                     registered_dataset_id, bds_dataset["most_recent_get_attempt_error_details"]
                 )
@@ -153,7 +154,7 @@ def add_or_update_registered_dataset(
                     "details": "{}".format(e),
                 }
             )
-            context["logger"].warning(
+            context.logger.warning(
                 "dataset id: {} - {}".format(
                     registered_dataset_id, bds_dataset["most_recent_get_attempt_error_details"]
                 )
@@ -161,7 +162,7 @@ def add_or_update_registered_dataset(
             insert_or_update_dataset(db_conn, bds_dataset)
 
 
-def get_randomised_redownload_after_n_hours(context: dict) -> int:
+def get_randomised_redownload_after_n_hours(context: BDSContext) -> int:
     hours_force_redownload = int(context["FORCE_REDOWNLOAD_AFTER_HOURS"])
 
     if hours_force_redownload > 8:
@@ -176,7 +177,7 @@ def dataset_downloaded_within(bds_dataset: dict, hours: int) -> bool:
 
 
 def check_dataset_etag_last_mod_header(
-    context: dict,
+    context: BDSContext,
     db_conn: psycopg.Connection,
     session: requests.Session,
     bds_dataset: dict,
@@ -194,7 +195,7 @@ def check_dataset_etag_last_mod_header(
             and head_response.headers["ETag"] != bds_dataset["last_known_good_dataset_server_header_etag"]
         ):
 
-            context["logger"].info(
+            context.logger.info(
                 "dataset id: {} - Last successful download within {} hours, "
                 "but ETag changed so redownloading".format(bds_dataset["id"], download_within_hours)
             )
@@ -205,7 +206,7 @@ def check_dataset_etag_last_mod_header(
             datetime.strptime(head_response.headers["Last-Modified"], "%a, %d %b %Y %H:%M:%S GMT")
         ) != set_timestamp_tz_utc(bds_dataset["last_known_good_dataset_server_header_last_modified"]):
 
-            context["logger"].info(
+            context.logger.info(
                 "dataset id: {} - Last successful download within {} hours, "
                 "but Last-Modified header changed so redownloading".format(bds_dataset["id"], download_within_hours)
             )
@@ -213,7 +214,7 @@ def check_dataset_etag_last_mod_header(
             update_dataset_head_request_fields(bds_dataset, attempt_time, head_response.status_code)
 
         else:
-            context["logger"].info(
+            context.logger.info(
                 "dataset id: {} - Last successful download within {} hours, "
                 "Last-Modified and ETag same, so not redownloading".format(bds_dataset["id"], download_within_hours)
             )
@@ -249,7 +250,7 @@ def check_dataset_etag_last_mod_header(
             | e.args[0]
         )
 
-        context["logger"].warning(
+        context.logger.warning(
             "dataset id: {} - {}".format(bds_dataset["id"], bds_dataset["most_recent_head_attempt_error_details"])
         )
 
@@ -263,17 +264,17 @@ def check_dataset_etag_last_mod_header(
         insert_or_update_dataset(db_conn, bds_dataset)
 
     except Exception as e:
-        context["logger"].warning(
+        context.logger.warning(
             "dataset id: {} - EXCEPTION with HEAD request, details: {}".format(bds_dataset["id"], e)
         )
         if "{}".format(e) == "str.replace() takes no keyword arguments":
-            context["logger"].error("Full traceback: " "{}".format(traceback.format_exc()))
+            context.logger.error("Full traceback: " "{}".format(traceback.format_exc()))
 
     return attempt_download
 
 
 def download_and_save_dataset(
-    context: dict,
+    context: BDSContext,
     session: requests.Session,
     az_blob_service: BlobServiceClient,
     bds_dataset: dict,
@@ -306,7 +307,7 @@ def download_and_save_dataset(
     hash_excluding_generated = get_hash_excluding_generated_timestamp(download_response.text, encoding)  # type: ignore
 
     if hash == bds_dataset["last_known_good_dataset_hash"]:
-        context["logger"].info(
+        context.logger.info(
             "dataset id: {} - Hash of download is identical to "
             "previous value, so not re-zipping and re-uploading to Azure".format(bds_dataset["id"])
         )
@@ -322,9 +323,7 @@ def download_and_save_dataset(
             encoding=encoding,
         )
 
-        context["logger"].debug(
-            "dataset id: {} - Azure XML upload response: {}".format(bds_dataset["id"], response_xml)
-        )
+        context.logger.debug("dataset id: {} - Azure XML upload response: {}".format(bds_dataset["id"], response_xml))
 
         response_zip = azure_upload_to_blob(
             az_blob_service,
@@ -339,8 +338,8 @@ def download_and_save_dataset(
             context["AZURE_STORAGE_BLOB_CONTAINER_NAME"],
             "{}/{}.xml".format(bds_dataset["reporting_org_short_name"], bds_dataset["short_name"]),
         ):
-            context["logger"].error("dataset id: {} - Azure XML upload failed")
-            context["logger"].debug(
+            context.logger.error("dataset id: {} - Azure XML upload failed")
+            context.logger.debug(
                 "dataset id: {} - Azure ZIP upload response: {}".format(bds_dataset["id"], response_xml)
             )
 

--- a/src/bulk_data_service/registry_changes_processor.py
+++ b/src/bulk_data_service/registry_changes_processor.py
@@ -7,6 +7,7 @@ from azure.servicebus import ServiceBusReceivedMessage
 from azure.servicebus.aio import ServiceBusClient, ServiceBusReceiver
 from azure.servicebus.exceptions import MessagingEntityNotFoundError, ServiceBusConnectionError
 
+from config.bds_context import BDSContext
 from utilities.dataset_reporting_org_utils import (
     get_new_dataset_db_record_from_mq_dataset,
     get_reporting_org_db_record_from_mq_reporting_org,
@@ -26,7 +27,7 @@ from utilities.exceptions import BulkDataServiceRuntimeError
 from utilities.misc import get_timestamp_as_str
 
 
-def registry_changes_processor_start(context: dict):
+def registry_changes_processor_start(context: BDSContext):
     try:
         asyncio.run(registry_changes_service_loop(context))
     except KeyboardInterrupt:
@@ -34,13 +35,13 @@ def registry_changes_processor_start(context: dict):
         print("User pressed Ctrl-C. Exiting")
 
 
-async def registry_changes_service_loop(context: dict):
+async def registry_changes_service_loop(context: BDSContext):
 
     sb_client = None
 
     while True:
         try:
-            context["logger"].debug(f"registry_changes_service_loop - mark - {get_timestamp_as_str()}")
+            context.logger.debug(f"registry_changes_service_loop - mark - {get_timestamp_as_str()}")
 
             if sb_client is None:
                 sb_client = ServiceBusClient.from_connection_string(context["AZURE_SERVICE_BUS_CONNECTION_STRING"])
@@ -50,7 +51,7 @@ async def registry_changes_service_loop(context: dict):
 
                 await asyncio.sleep(3)
             except MessagingEntityNotFoundError as e:
-                context["logger"].warning(
+                context.logger.warning(
                     f"registry_changes_service_loop - Connected to Azure Service Bus "
                     f"but could not find topic or subscription - {e}"
                 )
@@ -59,10 +60,10 @@ async def registry_changes_service_loop(context: dict):
                 await receiver.close()
 
         except ServiceBusConnectionError as e:
-            context["logger"].warning(f"registry_changes_service_loop - Could not connect to Azure Service Bus - {e}")
+            context.logger.warning(f"registry_changes_service_loop - Could not connect to Azure Service Bus - {e}")
             await asyncio.sleep(15)
         except Exception as e:
-            context["logger"].warning(f"registry_changes_service_loop - Unexpected Error - {e}")
+            context.logger.warning(f"registry_changes_service_loop - Unexpected Error - {e}")
             print(traceback.format_exc())
             await asyncio.sleep(15)
         finally:
@@ -71,7 +72,7 @@ async def registry_changes_service_loop(context: dict):
                 sb_client = None
 
 
-def get_sb_receiver(context: dict, sb_client: ServiceBusClient) -> ServiceBusReceiver:
+def get_sb_receiver(context: BDSContext, sb_client: ServiceBusClient) -> ServiceBusReceiver:
 
     topic = context["AZURE_SERVICE_BUS_REGISTRY_TOPIC_NAME"]
     subscription = context["AZURE_SERVICE_BUS_REGISTRY_SUB_NAME"]
@@ -80,7 +81,7 @@ def get_sb_receiver(context: dict, sb_client: ServiceBusClient) -> ServiceBusRec
     return sb_client.get_subscription_receiver(topic, subscription, max_wait_time=wait_time)
 
 
-async def fetch_and_process_messages(context: dict, sb_client: ServiceBusClient) -> ServiceBusReceiver:
+async def fetch_and_process_messages(context: BDSContext, sb_client: ServiceBusClient) -> ServiceBusReceiver:
 
     receiver = get_sb_receiver(context, sb_client)
 
@@ -90,7 +91,7 @@ async def fetch_and_process_messages(context: dict, sb_client: ServiceBusClient)
         try:
             await process_message(context, message)
         except BulkDataServiceRuntimeError as e:
-            context["logger"].error(f"process_message - Error processing message: {e}")
+            context.logger.error(f"process_message - Error processing message: {e}")
         finally:
             await receiver.complete_message(message)
 
@@ -98,7 +99,7 @@ async def fetch_and_process_messages(context: dict, sb_client: ServiceBusClient)
 
 
 async def fetch_messages(
-    context: dict, receiver: ServiceBusReceiver, num_messages: int = 5
+    context: BDSContext, receiver: ServiceBusReceiver, num_messages: int = 5
 ) -> list[ServiceBusReceivedMessage]:
 
     wait_time = context["AZURE_SERVICE_BUS_WAIT_TIME"]
@@ -106,7 +107,7 @@ async def fetch_messages(
     return await receiver.receive_messages(max_wait_time=wait_time, max_message_count=num_messages)
 
 
-async def process_message(context: dict, msg: ServiceBusReceivedMessage):
+async def process_message(context: BDSContext, msg: ServiceBusReceivedMessage):
     if msg.application_properties is not None and b"message_type" in msg.application_properties:
         message_type = msg.application_properties[b"message_type"].decode("utf-8")  # type: ignore[union-attr]
         await dispatch_message(context, message_type, json.loads(str(msg)))
@@ -116,7 +117,7 @@ async def process_message(context: dict, msg: ServiceBusReceivedMessage):
         )
 
 
-async def dispatch_message(context: dict, message_type: str, message_payload: dict):
+async def dispatch_message(context: BDSContext, message_type: str, message_payload: dict):
     match message_type:
         case "DATASET_CREATED":
             create_new_dataset(context, message_payload)
@@ -141,7 +142,7 @@ async def dispatch_message(context: dict, message_type: str, message_payload: di
             print(json.dumps(message_payload))
 
 
-def create_new_reporting_org(context: dict, message_payload: dict):
+def create_new_reporting_org(context: BDSContext, message_payload: dict):
     reporting_org_db_record = get_reporting_org_in_bds(context, uuid.UUID(message_payload["reporting_org"]["id"]))
 
     if reporting_org_db_record is not None:
@@ -154,10 +155,10 @@ def create_new_reporting_org(context: dict, message_payload: dict):
     new_reporting_org_db_record = get_reporting_org_db_record_from_mq_reporting_org(message_payload["reporting_org"])
     with get_db_connection(context) as connection:
         insert_or_update_reporting_org(connection, new_reporting_org_db_record)
-    context["logger"].info(f"Created reporting org with ID {new_reporting_org_db_record["id"]}")
+    context.logger.info(f"Created reporting org with ID {new_reporting_org_db_record["id"]}")
 
 
-def update_reporting_org(context: dict, message_payload: dict):
+def update_reporting_org(context: BDSContext, message_payload: dict):
     reporting_org_db_record = get_reporting_org_in_bds(context, uuid.UUID(message_payload["reporting_org"]["id"]))
 
     if reporting_org_db_record is None:
@@ -171,10 +172,10 @@ def update_reporting_org(context: dict, message_payload: dict):
 
     with get_db_connection(context) as connection:
         insert_or_update_reporting_org(connection, reporting_org_db_record)
-    context["logger"].info(f"Updated metadata for reporting org ID {reporting_org_db_record["id"]}")
+    context.logger.info(f"Updated metadata for reporting org ID {reporting_org_db_record["id"]}")
 
 
-def delete_reporting_org(context: dict, message_payload: dict):
+def delete_reporting_org(context: BDSContext, message_payload: dict):
 
     reporting_org_db_record = get_reporting_org_in_bds(context, uuid.UUID(message_payload["reporting_org"]["id"]))
 
@@ -188,10 +189,10 @@ def delete_reporting_org(context: dict, message_payload: dict):
     with get_db_connection(context) as connection:
         remove_reporting_org_from_db(connection, message_payload["reporting_org"]["id"])
 
-    context["logger"].info(f"Deleted reporting org with ID {message_payload["reporting_org"]["id"]}")
+    context.logger.info(f"Deleted reporting org with ID {message_payload["reporting_org"]["id"]}")
 
 
-def create_new_dataset(context: dict, message_payload: dict):
+def create_new_dataset(context: BDSContext, message_payload: dict):
     dataset_db_record = get_dataset_in_bds(context, uuid.UUID(message_payload["dataset"]["id"]))
 
     if dataset_db_record is not None:
@@ -215,10 +216,10 @@ def create_new_dataset(context: dict, message_payload: dict):
     new_dataset_db_record = get_new_dataset_db_record_from_mq_dataset(message_payload["dataset"])
     with get_db_connection(context) as connection:
         insert_or_update_dataset(connection, new_dataset_db_record)
-    context["logger"].info(f"Created dataset with ID {new_dataset_db_record["id"]}")
+    context.logger.info(f"Created dataset with ID {new_dataset_db_record["id"]}")
 
 
-def update_dataset(context: dict, message_payload: dict):
+def update_dataset(context: BDSContext, message_payload: dict):
     dataset_db_record = get_dataset_in_bds(context, uuid.UUID(message_payload["dataset"]["id"]))
 
     if dataset_db_record is None:
@@ -254,10 +255,10 @@ def update_dataset(context: dict, message_payload: dict):
 
     with get_db_connection(context) as connection:
         update_dataset_registration_data(connection, dataset_db_record)
-    context["logger"].info(f"Updated metadata for dataset ID {dataset_db_record["id"]}")
+    context.logger.info(f"Updated metadata for dataset ID {dataset_db_record["id"]}")
 
 
-def delete_dataset(context: dict, message_payload: dict):
+def delete_dataset(context: BDSContext, message_payload: dict):
 
     dataset_db_record = get_dataset_in_bds(context, uuid.UUID(message_payload["dataset"]["id"]))
 
@@ -271,4 +272,4 @@ def delete_dataset(context: dict, message_payload: dict):
     with get_db_connection(context) as connection:
         remove_dataset_from_db(connection, message_payload["dataset"]["id"])
 
-    context["logger"].info(f"Deleted dataset with ID {message_payload["dataset"]["id"]}")
+    context.logger.info(f"Deleted dataset with ID {message_payload["dataset"]["id"]}")

--- a/src/bulk_data_service/reporting_org_sync.py
+++ b/src/bulk_data_service/reporting_org_sync.py
@@ -1,9 +1,10 @@
 import uuid
 
+from config.bds_context import BDSContext
 from utilities.db import get_db_connection, insert_or_update_reporting_org, remove_reporting_org_from_db
 
 
-def add_or_update_reporting_orgs(context: dict, registered_reporting_orgs: dict[uuid.UUID, dict]):
+def add_or_update_reporting_orgs(context: BDSContext, registered_reporting_orgs: dict[uuid.UUID, dict]):
 
     db_conn = get_db_connection(context)
 
@@ -14,7 +15,7 @@ def add_or_update_reporting_orgs(context: dict, registered_reporting_orgs: dict[
 
 
 def remove_deleted_reporting_orgs_from_bds(
-    context: dict, reporting_orgs_in_bds: dict[uuid.UUID, dict], registered_reporting_orgs: dict[uuid.UUID, dict]
+    context: BDSContext, reporting_orgs_in_bds: dict[uuid.UUID, dict], registered_reporting_orgs: dict[uuid.UUID, dict]
 ):
 
     db_conn = get_db_connection(context)

--- a/src/bulk_data_service/zipper.py
+++ b/src/bulk_data_service/zipper.py
@@ -8,13 +8,14 @@ from azure.core.exceptions import ResourceNotFoundError
 from azure.storage.blob import BlobServiceClient
 
 from bulk_data_service.zippers import CodeforIATILegacyZipper, IATIBulkDataServiceZipper
+from config.bds_context import BDSContext
 from utilities.azure import azure_download_blob, get_azure_blob_name, get_azure_container_name
 from utilities.db import get_datasets_in_bds, get_reporting_orgs_in_bds
 from utilities.misc import dataset_has_iati_xml_download
 from utilities.prometheus import update_prom_metric
 
 
-def zipper(context: dict):
+def zipper(context: BDSContext):
 
     datasets = get_datasets_in_bds(context)
 
@@ -27,7 +28,7 @@ def zipper(context: dict):
 
 
 def zipper_service_loop(
-    context: dict,
+    context: BDSContext,
     datasets_in_working_dir: dict[uuid.UUID, dict],
     datasets_in_bds: dict[uuid.UUID, dict],
     reporting_orgs: dict[uuid.UUID, dict],
@@ -40,14 +41,14 @@ def zipper_service_loop(
 
 
 def zipper_run(
-    context: dict,
+    context: BDSContext,
     datasets_in_working_dir: dict[uuid.UUID, dict],
     datasets_in_bds: dict[uuid.UUID, dict],
     reporting_orgs: dict[uuid.UUID, dict],
 ):
 
     run_start = datetime.datetime.now(datetime.UTC)
-    context["logger"].info("Zipper run starting")
+    context.logger.info("Zipper run starting")
 
     setup_working_dir_with_downloaded_datasets(context, datasets_in_working_dir, datasets_in_bds)
 
@@ -81,12 +82,12 @@ def zipper_run(
         zip_creator.upload()
 
     run_end = datetime.datetime.now(datetime.UTC)
-    context["logger"].info("Zipper run finished in {}.".format(run_end - run_start))
+    context.logger.info("Zipper run finished in {}.".format(run_end - run_start))
     update_prom_metric(context, "zipper_run_duration", (run_end - run_start).seconds)
 
 
 def setup_working_dir_with_downloaded_datasets(
-    context: dict, datasets_in_working_dir: dict[uuid.UUID, dict], datasets_in_bds: dict[uuid.UUID, dict]
+    context: BDSContext, datasets_in_working_dir: dict[uuid.UUID, dict], datasets_in_bds: dict[uuid.UUID, dict]
 ):
 
     clean_working_dir(context, datasets_in_working_dir)
@@ -103,7 +104,7 @@ def setup_working_dir_with_downloaded_datasets(
         != datasets_with_downloads[k]["last_known_good_dataset_hash"]
     }
 
-    context["logger"].info(
+    context.logger.info(
         "Found {} datasets with downloads. "
         "{} are new or updated and will be (re-)downloaded.".format(
             len(datasets_with_downloads), len(new_or_updated_datasets)
@@ -116,14 +117,14 @@ def setup_working_dir_with_downloaded_datasets(
     datasets_in_working_dir.update(datasets_with_downloads)
 
 
-def clean_working_dir(context: dict, datasets_in_zip: dict[uuid.UUID, dict]):
+def clean_working_dir(context: BDSContext, datasets_in_zip: dict[uuid.UUID, dict]):
     if len(datasets_in_zip) == 0:
-        context["logger"].info("First zip run of session, so deleting all XML " "files in the ZIP working dir.")
+        context.logger.info("First zip run of session, so deleting all XML " "files in the ZIP working dir.")
         shutil.rmtree("{}/{}".format(context["ZIP_WORKING_DIR"], "iati-data"), ignore_errors=True)
 
 
 def remove_datasets_without_dls_from_working_dir(
-    context: dict, datasets_in_zip: dict[uuid.UUID, dict], datasets_in_bds: dict[uuid.UUID, dict]
+    context: BDSContext, datasets_in_zip: dict[uuid.UUID, dict], datasets_in_bds: dict[uuid.UUID, dict]
 ):
     datasets_removed = {k: v for k, v in datasets_in_zip.items() if v["id"] not in datasets_in_bds}
 
@@ -131,7 +132,7 @@ def remove_datasets_without_dls_from_working_dir(
         delete_local_xml_from_zip_working_dir(context, dataset)
 
 
-def download_new_or_updated_to_working_dir(context: dict, updated_datasets: dict[uuid.UUID, dict]):
+def download_new_or_updated_to_working_dir(context: BDSContext, updated_datasets: dict[uuid.UUID, dict]):
 
     az_blob_service = BlobServiceClient.from_connection_string(context["AZURE_STORAGE_CONNECTION_STRING"])
 
@@ -144,30 +145,30 @@ def download_new_or_updated_to_working_dir(context: dict, updated_datasets: dict
 
         os.makedirs(os.path.dirname(filename), exist_ok=True)
 
-        context["logger"].info("dataset id: {} - Downloading".format(dataset["id"]))
+        context.logger.info("dataset id: {} - Downloading".format(dataset["id"]))
 
         try:
             azure_download_blob(az_blob_service, xml_container_name, get_azure_blob_name(dataset, "xml"), filename)
         except ResourceNotFoundError as e:
-            context["logger"].error(
+            context.logger.error(
                 "dataset id: {} - Failed to download from Azure: {}".format(dataset["id"], e).replace("\n", " ")
             )
 
     az_blob_service.close()
 
 
-def get_local_pathname_dataset_xml(context: dict, dataset: dict) -> str:
+def get_local_pathname_dataset_xml(context: BDSContext, dataset: dict) -> str:
     return "{}/iati-data/datasets/{}".format(context["ZIP_WORKING_DIR"], get_azure_blob_name(dataset, "xml"))
 
 
-def delete_local_xml_from_zip_working_dir(context: dict, dataset: dict):
+def delete_local_xml_from_zip_working_dir(context: BDSContext, dataset: dict):
     dataset_local_xml = get_local_pathname_dataset_xml(context, dataset)
 
     if os.path.exists(dataset_local_xml):
         try:
             os.remove(dataset_local_xml)
         except FileNotFoundError as e:
-            context["logger"].error(
+            context.logger.error(
                 "dataset id: {} - Error removing local XML file from "
                 "ZIP working dir. Details: {}.".format(dataset["id"], e)
             )

--- a/src/bulk_data_service/zippers.py
+++ b/src/bulk_data_service/zippers.py
@@ -50,7 +50,7 @@ class IATIDataZipper(ABC):
         return "iati-data"
 
     def zip(self):
-        self.context["logger"].info("Zipping {} datasets.".format(get_number_xml_files_in_dir(self.zip_working_dir)))
+        self.context.logger.info("Zipping {} datasets.".format(get_number_xml_files_in_dir(self.zip_working_dir)))
         shutil.make_archive(
             self.get_zip_local_pathname_no_extension(),
             "zip",
@@ -59,7 +59,7 @@ class IATIDataZipper(ABC):
         )
 
     def upload(self):
-        self.context["logger"].info(
+        self.context.logger.info(
             "Uploading {} ZIP to Azure with filename: {}.".format(self.zip_type, self.get_zip_local_filename())
         )
         upload_zip_to_azure(self.context, self.get_zip_local_pathname(), self.get_zip_local_filename())

--- a/src/config/bds_context.py
+++ b/src/config/bds_context.py
@@ -1,0 +1,13 @@
+import abc
+import logging
+from collections import UserDict
+
+
+class BDSContext(UserDict, metaclass=abc.ABCMeta):
+    def __init__(self, dict: dict, logger: logging.Logger):
+        self._logger = logger
+        UserDict.__init__(self, dict)
+
+    @property
+    def logger(self) -> logging.Logger:
+        return self._logger

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -32,14 +32,14 @@ _config_variables = [
 ]
 
 
-def get_config() -> dict[str, str | float]:
-    config: dict[str, str | float] = {env_var: os.getenv(env_var, "") for env_var in _config_variables}
+def get_basic_config() -> dict:
+    config = {env_var: os.getenv(env_var, "") for env_var in _config_variables}
 
-    config["WEB_BASE_URL"] = config["WEB_BASE_URL"].strip("/")  # type: ignore[union-attr]
+    config["WEB_BASE_URL"] = config["WEB_BASE_URL"].strip("/")
 
     config["BULK_DATA_SERVICE_VERSION"] = get_app_version()
 
-    config["AZURE_SERVICE_BUS_WAIT_TIME"] = float(config["AZURE_SERVICE_BUS_WAIT_TIME"])
+    config["AZURE_SERVICE_BUS_WAIT_TIME"] = float(config["AZURE_SERVICE_BUS_WAIT_TIME"])  # type: ignore
 
     return config
 

--- a/src/config/initialisation.py
+++ b/src/config/initialisation.py
@@ -1,7 +1,9 @@
 import urllib3
 
+from config.bds_context import BDSContext
 
-def misc_global_initialisation(context: dict):
+
+def misc_global_initialisation(context: BDSContext):
     # these warnings are turned off because many IATI XML files are served
     # from web servers with misconfigured certificates, so we can't verify
     # certificates, and without this the logs fill up with warnings saying we

--- a/src/dataset_registration/iati_register_your_data.py
+++ b/src/dataset_registration/iati_register_your_data.py
@@ -2,10 +2,12 @@ import uuid
 
 import requests
 
+from config.bds_context import BDSContext
 
-def fetch_datasets_metadata(context: dict, session: requests.Session) -> dict[uuid.UUID, dict]:
+
+def fetch_datasets_metadata(context: BDSContext, session: requests.Session) -> dict[uuid.UUID, dict]:
     return {}
 
 
-def fetch_reporting_orgs_metadata(context: dict, session: requests.Session) -> dict[uuid.UUID, dict]:
+def fetch_reporting_orgs_metadata(context: BDSContext, session: requests.Session) -> dict[uuid.UUID, dict]:
     return {}

--- a/src/dataset_registration/iati_registry_ckan.py
+++ b/src/dataset_registration/iati_registry_ckan.py
@@ -6,11 +6,12 @@ from typing import Any
 
 import requests
 
+from config.bds_context import BDSContext
 from utilities.http import add_qs_params_to_url, http_get_json
 from utilities.misc import is_str_valid_uuid
 
 
-def fetch_reporting_orgs_metadata(context: dict) -> dict[uuid.UUID, dict]:
+def fetch_reporting_orgs_metadata(context: BDSContext) -> dict[uuid.UUID, dict]:
 
     reporting_org_metadata = {}
 
@@ -25,7 +26,7 @@ def fetch_reporting_orgs_metadata(context: dict) -> dict[uuid.UUID, dict]:
     return reporting_org_metadata
 
 
-def fetch_reporting_orgs_from_iati_registry(context: dict) -> list[dict]:
+def fetch_reporting_orgs_from_iati_registry(context: BDSContext) -> list[dict]:
 
     session = requests.Session()
 
@@ -48,7 +49,7 @@ def fetch_reporting_orgs_from_iati_registry(context: dict) -> list[dict]:
         reporting_orgs_url = add_qs_params_to_url(
             reporting_orgs_base_url, {"limit": batch_size, "offset": reporting_orgs_metadata_downloaded}
         )
-        context["logger"].info("Fetching reporting orgs from URL: {}".format(reporting_orgs_url))
+        context.logger.info("Fetching reporting orgs from URL: {}".format(reporting_orgs_url))
 
         response = http_get_json(session, reporting_orgs_url)
 
@@ -56,7 +57,7 @@ def fetch_reporting_orgs_from_iati_registry(context: dict) -> list[dict]:
 
         reporting_orgs_metadata_downloaded += len(response["result"])
 
-    context["logger"].info("Fetched metadata for {} reporting orgs".format(len(reporting_orgs_metadata)))
+    context.logger.info("Fetched metadata for {} reporting orgs".format(len(reporting_orgs_metadata)))
 
     return reporting_orgs_metadata
 
@@ -71,14 +72,14 @@ def convert_ckan_reporting_org_metadata(reporting_org: dict):
     }
 
 
-def fetch_datasets_metadata(context: dict, reporting_orgs: dict) -> dict[uuid.UUID, dict]:
+def fetch_datasets_metadata(context: BDSContext, reporting_orgs: dict) -> dict[uuid.UUID, dict]:
     session = requests.Session()
 
     datasets_list_from_registry = fetch_datasets_metadata_from_iati_registry(context, session)
 
     random.shuffle(datasets_list_from_registry)
 
-    cleaned_datasets_metadata = clean_datasets_metadata(context["logger"], datasets_list_from_registry)
+    cleaned_datasets_metadata = clean_datasets_metadata(context.logger, datasets_list_from_registry)
 
     augmented_datasets_metadata = add_publisher_metadata(cleaned_datasets_metadata, reporting_orgs)
 
@@ -87,7 +88,7 @@ def fetch_datasets_metadata(context: dict, reporting_orgs: dict) -> dict[uuid.UU
     return datasets_metadata
 
 
-def fetch_datasets_metadata_from_iati_registry(context: dict, session: requests.Session) -> list[dict]:
+def fetch_datasets_metadata_from_iati_registry(context: BDSContext, session: requests.Session) -> list[dict]:
 
     api_url = context["DATA_REGISTRY_BASE_URL"]
 

--- a/src/iati_bulk_data_service.py
+++ b/src/iati_bulk_data_service.py
@@ -3,7 +3,8 @@ import argparse
 from bulk_data_service.checker import checker
 from bulk_data_service.registry_changes_processor import registry_changes_processor_start
 from bulk_data_service.zipper import zipper
-from config.config import get_config
+from config.bds_context import BDSContext
+from config.config import get_basic_config
 from config.initialisation import misc_global_initialisation
 from utilities.azure import create_azure_blob_containers
 from utilities.db import apply_db_migrations
@@ -13,15 +14,13 @@ from utilities.prometheus import initialise_prometheus_client
 
 def main(args: argparse.Namespace):
 
-    config = get_config()
+    config = get_basic_config()
 
-    logger = initialise_logging(config)
+    config = config | {"single_run": args.single_run, "run_for_n_datasets": args.run_for_n_datasets}
 
-    context = config | {"logger": logger, "single_run": args.single_run, "run_for_n_datasets": args.run_for_n_datasets}
+    context = BDSContext(config, initialise_logging(config))
 
-    context["logger"].info(  # type: ignore
-        "Bulk Data Service {} initialising...".format(context["BULK_DATA_SERVICE_VERSION"])
-    )
+    context.logger.info("Bulk Data Service {} initialising...".format(context["BULK_DATA_SERVICE_VERSION"]))
 
     apply_db_migrations(context)
 
@@ -29,9 +28,9 @@ def main(args: argparse.Namespace):
 
     misc_global_initialisation(context)
 
-    context = initialise_prometheus_client(context)
+    initialise_prometheus_client(context)
 
-    context["logger"].info("Bulk Data Service {} initialisation complete".format(context["BULK_DATA_SERVICE_VERSION"]))
+    context.logger.info("Bulk Data Service {} initialisation complete".format(context["BULK_DATA_SERVICE_VERSION"]))
 
     if args.operation == "checker":
         checker(context)

--- a/src/utilities/azure.py
+++ b/src/utilities/azure.py
@@ -3,6 +3,8 @@ from typing import Any
 import azure
 from azure.storage.blob import BlobServiceClient, ContentSettings
 
+from config.bds_context import BDSContext
+
 
 def azure_blob_exists(az_blob_service: BlobServiceClient, container_name: str, blob_name: str) -> bool:
     blob_client = az_blob_service.get_blob_client(container_name, blob_name)
@@ -39,7 +41,7 @@ def azure_upload_to_blob(
     return blob_client.upload_blob(content, overwrite=True, content_settings=content_settings)
 
 
-def create_azure_blob_containers(context: dict):
+def create_azure_blob_containers(context: BDSContext):
     blob_service = BlobServiceClient.from_connection_string(context["AZURE_STORAGE_CONNECTION_STRING"])
 
     containers = blob_service.list_containers()
@@ -50,7 +52,7 @@ def create_azure_blob_containers(context: dict):
             blob_service.create_container(context["AZURE_STORAGE_BLOB_CONTAINER_NAME"])
             container_names.append(context["AZURE_STORAGE_BLOB_CONTAINER_NAME"])
     except Exception as e:
-        context["logger"].error(
+        context.logger.error(
             "Could not create Azure blob storage container. "
             "Container name: {}. "
             "Error details: {}".format(
@@ -63,7 +65,7 @@ def create_azure_blob_containers(context: dict):
         blob_service.close()
 
 
-def delete_azure_blob_containers(context: dict):
+def delete_azure_blob_containers(context: BDSContext):
     blob_service = BlobServiceClient.from_connection_string(context["AZURE_STORAGE_CONNECTION_STRING"])
 
     containers = blob_service.list_containers()
@@ -74,13 +76,15 @@ def delete_azure_blob_containers(context: dict):
             blob_service.delete_container(context["AZURE_STORAGE_BLOB_CONTAINER_NAME"])
             container_names.remove(context["AZURE_STORAGE_BLOB_CONTAINER_NAME"])
     except Exception as e:
-        context["logger"].error("Could not delete Azure blob storage container: {}".format(e))
+        context.logger.error("Could not delete Azure blob storage container: {}".format(e))
         raise e
     finally:
         blob_service.close()
 
 
-def delete_azure_iati_blob(context: dict, blob_service_client: BlobServiceClient, dataset: dict, iati_blob_type: str):
+def delete_azure_iati_blob(
+    context: BDSContext, blob_service_client: BlobServiceClient, dataset: dict, iati_blob_type: str
+):
 
     container_name = get_azure_container_name(context, iati_blob_type)
 
@@ -91,7 +95,7 @@ def delete_azure_iati_blob(context: dict, blob_service_client: BlobServiceClient
 
         blob_client.delete_blob()
     except azure.core.exceptions.ResourceNotFoundError as e:
-        context["logger"].error(
+        context.logger.error(
             "dataset id: {} - Problem deleting blob that was "
             "expected to exist: {}".format(dataset["id"], e).replace("\n", "")
         )
@@ -99,7 +103,7 @@ def delete_azure_iati_blob(context: dict, blob_service_client: BlobServiceClient
         blob_client.close()
 
 
-def get_azure_container_name(context: dict, iati_blob_type: str) -> str:
+def get_azure_container_name(context: BDSContext, iati_blob_type: str) -> str:
     return context["AZURE_STORAGE_BLOB_CONTAINER_NAME"]
 
 
@@ -107,7 +111,7 @@ def get_azure_blob_name(dataset: dict, iati_blob_type: str) -> str:
     return "{}/{}.{}".format(dataset["reporting_org_short_name"], dataset["short_name"], iati_blob_type)
 
 
-def get_azure_blob_public_url(context: dict, dataset: dict, iati_blob_type: str) -> str:
+def get_azure_blob_public_url(context: BDSContext, dataset: dict, iati_blob_type: str) -> str:
     blob_name = get_azure_container_name(context, iati_blob_type)
     blob_name_for_url = "{}/".format(blob_name) if blob_name != "$web" else ""
 
@@ -118,7 +122,7 @@ def get_azure_blob_public_url(context: dict, dataset: dict, iati_blob_type: str)
     )
 
 
-def upload_zip_to_azure(context: dict, zip_local_pathname: str, zip_azure_filename: str):
+def upload_zip_to_azure(context: BDSContext, zip_local_pathname: str, zip_azure_filename: str):
     az_blob_service = BlobServiceClient.from_connection_string(context["AZURE_STORAGE_CONNECTION_STRING"])
 
     blob_client = az_blob_service.get_blob_client(context["AZURE_STORAGE_BLOB_CONTAINER_NAME"], zip_azure_filename)

--- a/src/utilities/db.py
+++ b/src/utilities/db.py
@@ -5,8 +5,10 @@ import psycopg
 from psycopg.rows import dict_row
 from yoyo import get_backend, read_migrations  # type: ignore
 
+from config.bds_context import BDSContext
 
-def apply_db_migrations(context: dict):
+
+def apply_db_migrations(context: BDSContext):
 
     backend = get_backend(
         "postgresql+psycopg://{}:{}@{}:{}/{}".format(
@@ -22,7 +24,7 @@ def apply_db_migrations(context: dict):
         backend.apply_migrations(backend.to_apply(migrations))
 
 
-def get_db_connection(context: dict) -> psycopg.Connection:
+def get_db_connection(context: BDSContext) -> psycopg.Connection:
     connection = psycopg.connect(
         dbname=context["DB_NAME"],
         user=context["DB_USER"],
@@ -35,7 +37,7 @@ def get_db_connection(context: dict) -> psycopg.Connection:
     return connection
 
 
-def get_datasets_in_bds(context: dict) -> dict[uuid.UUID, dict]:
+def get_datasets_in_bds(context: BDSContext) -> dict[uuid.UUID, dict]:
 
     connection = get_db_connection(context)
     cursor = connection.cursor(row_factory=dict_row)
@@ -48,7 +50,7 @@ def get_datasets_in_bds(context: dict) -> dict[uuid.UUID, dict]:
     return results
 
 
-def get_dataset_in_bds(context: dict, dataset_id: uuid.UUID) -> dict | None:
+def get_dataset_in_bds(context: BDSContext, dataset_id: uuid.UUID) -> dict | None:
 
     connection = get_db_connection(context)
     cursor = connection.cursor(row_factory=dict_row)
@@ -59,7 +61,7 @@ def get_dataset_in_bds(context: dict, dataset_id: uuid.UUID) -> dict | None:
     return result
 
 
-def get_reporting_org_in_bds(context: dict, reporting_org_id: uuid.UUID) -> dict | None:
+def get_reporting_org_in_bds(context: BDSContext, reporting_org_id: uuid.UUID) -> dict | None:
 
     connection = get_db_connection(context)
     cursor = connection.cursor(row_factory=dict_row)
@@ -70,7 +72,7 @@ def get_reporting_org_in_bds(context: dict, reporting_org_id: uuid.UUID) -> dict
     return result
 
 
-def get_reporting_orgs_in_bds(context: dict) -> dict[uuid.UUID, dict]:
+def get_reporting_orgs_in_bds(context: BDSContext) -> dict[uuid.UUID, dict]:
 
     connection = get_db_connection(context)
     cursor = connection.cursor(row_factory=dict_row)
@@ -190,7 +192,7 @@ def remove_dataset_from_db(connection: psycopg.Connection, dataset_id):
     connection.commit()
 
 
-def execute_scalar_db_query(context: dict, sql: str) -> Any:
+def execute_scalar_db_query(context: BDSContext, sql: str) -> Any:
     connection = get_db_connection(context)
     value = execute_scalar_db_query_with_conn(connection, sql)
     connection.close()

--- a/src/utilities/http.py
+++ b/src/utilities/http.py
@@ -7,6 +7,8 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 
+from config.bds_context import BDSContext
+
 
 def add_qs_params_to_url(url: str, qs_params: dict) -> str:
     scheme, netloc, path, qs, fragment = urlsplit(url)
@@ -38,7 +40,7 @@ def parse_last_modified_header(last_modified_header: str) -> Optional[datetime.d
     return last_modified_header_parsed
 
 
-def get_requests_session(context: dict) -> requests.Session:
+def get_requests_session(context: BDSContext) -> requests.Session:
     session = requests.Session()
     session.headers.update({"User-Agent": "IATI Bulk Data Service {}".format(context["BULK_DATA_SERVICE_VERSION"])})
     retries = Retry(total=2, backoff_factor=0.1)

--- a/src/utilities/prometheus.py
+++ b/src/utilities/prometheus.py
@@ -1,5 +1,6 @@
 from prometheus_client import Gauge, start_http_server
 
+from config.bds_context import BDSContext
 from utilities.db import execute_scalar_db_query_with_conn, get_db_connection
 
 
@@ -36,7 +37,7 @@ def get_metric_definition(metric_name: str) -> tuple[str, str, str | None]:
     return list(filter(lambda m: m[0] == metric_name, get_metrics_definitions()))[0]
 
 
-def initialise_prometheus_client(context: dict) -> dict:
+def initialise_prometheus_client(context: BDSContext):
 
     context["prom_metrics"] = {}
 
@@ -44,10 +45,8 @@ def initialise_prometheus_client(context: dict) -> dict:
 
     start_http_server(9090)
 
-    return context
 
-
-def update_metrics_from_db(context: dict) -> dict:
+def update_metrics_from_db(context: BDSContext):
     metrics_with_sql = list(filter(lambda m: m[2] is not None, get_metrics_definitions()))
 
     db_conn = get_db_connection(context)
@@ -58,10 +57,8 @@ def update_metrics_from_db(context: dict) -> dict:
 
     db_conn.close()
 
-    return context
 
-
-def get_prom_metric(context: dict, metric_name: str):
+def get_prom_metric(context: BDSContext, metric_name: str):
 
     if metric_name not in context["prom_metrics"]:
         metric_def = get_metric_definition(metric_name)
@@ -70,6 +67,6 @@ def get_prom_metric(context: dict, metric_name: str):
     return context["prom_metrics"][metric_name]
 
 
-def update_prom_metric(context: dict, metric_name: str, metric_value: int):
+def update_prom_metric(context: BDSContext, metric_name: str, metric_value: int):
 
     get_prom_metric(context, metric_name).set(metric_value)

--- a/tests/helpers/azure_service_bus_helpers.py
+++ b/tests/helpers/azure_service_bus_helpers.py
@@ -5,6 +5,7 @@ import pytest
 import pytest_asyncio
 from azure.servicebus import ServiceBusMessage
 from azure.servicebus.aio import ServiceBusClient, ServiceBusReceiver
+from config.bds_context import BDSContext
 
 from bulk_data_service.registry_changes_processor import fetch_messages, get_sb_receiver, process_message
 from helpers.mq_data_helpers import get_dataset_message_payload, get_reporting_org_message_payload
@@ -19,7 +20,7 @@ async def service_bus_context(get_and_clear_up_context):
     await teardown_mq(context, sbclient, sbreceiver)
 
 
-async def process_pending_messages(context: dict, sbreceiver: ServiceBusReceiver, should_raise_exception: bool):
+async def process_pending_messages(context: BDSContext, sbreceiver: ServiceBusReceiver, should_raise_exception: bool):
     msgs = await fetch_messages(context, sbreceiver, num_messages=1)
 
     for message in msgs:
@@ -31,7 +32,7 @@ async def process_pending_messages(context: dict, sbreceiver: ServiceBusReceiver
         await sbreceiver.complete_message(message)
 
 
-async def initialise_mq(context: dict) -> tuple[ServiceBusClient, ServiceBusReceiver]:
+async def initialise_mq(context: BDSContext) -> tuple[ServiceBusClient, ServiceBusReceiver]:
     sbclient = ServiceBusClient.from_connection_string(context["AZURE_SERVICE_BUS_CONNECTION_STRING"])
 
     sbreceiver = get_sb_receiver(context, sbclient)
@@ -41,19 +42,19 @@ async def initialise_mq(context: dict) -> tuple[ServiceBusClient, ServiceBusRece
     return (sbclient, sbreceiver)
 
 
-async def teardown_mq(context: dict, sbclient: ServiceBusClient, sbreceiver: ServiceBusReceiver):
+async def teardown_mq(context: BDSContext, sbclient: ServiceBusClient, sbreceiver: ServiceBusReceiver):
     await sbreceiver.close()
     await sbclient.close()
 
 
-async def clear_messages_from_subscription(context: dict, sbreceiver: ServiceBusReceiver):
+async def clear_messages_from_subscription(context: BDSContext, sbreceiver: ServiceBusReceiver):
     messages = await sbreceiver.receive_messages(50, max_wait_time=0.1)
     for message in messages:
         await sbreceiver.complete_message(message)
 
 
 async def send_dataset_created_message(
-    context: dict, sbclient: ServiceBusClient, dataset_id: UUID, reporting_org_id: UUID
+    context: BDSContext, sbclient: ServiceBusClient, dataset_id: UUID, reporting_org_id: UUID
 ):
 
     dataset_db_record = {
@@ -68,7 +69,7 @@ async def send_dataset_created_message(
     return await generate_and_send_message(context, sbclient, "dataset", "created", dataset_db_record)
 
 
-async def send_reporting_org_created_message(context: dict, sbclient: ServiceBusClient, reporting_org_id: UUID):
+async def send_reporting_org_created_message(context: BDSContext, sbclient: ServiceBusClient, reporting_org_id: UUID):
 
     reporting_org_db_record = {
         "id": reporting_org_id,
@@ -83,7 +84,7 @@ async def send_reporting_org_created_message(context: dict, sbclient: ServiceBus
 
 
 async def generate_and_send_message(
-    context: dict,
+    context: BDSContext,
     sbclient: ServiceBusClient,
     record_type: str,
     update_type: str,
@@ -98,7 +99,7 @@ async def generate_and_send_message(
 
 
 async def send_reporting_org_message(
-    context: dict,
+    context: BDSContext,
     sbclient: ServiceBusClient,
     reporting_org: dict,
     update_type: str,
@@ -109,7 +110,7 @@ async def send_reporting_org_message(
     return await send_message(context, sbclient, msg_payload)
 
 
-async def send_message(context: dict, sbclient: ServiceBusClient, payload: dict) -> dict:
+async def send_message(context: BDSContext, sbclient: ServiceBusClient, payload: dict) -> dict:
 
     payload_str = json.dumps(payload, indent=2)
 

--- a/tests/helpers/data_helpers.py
+++ b/tests/helpers/data_helpers.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import uuid
+from config.bds_context import BDSContext
 
 from bulk_data_service.dataset_indexing import get_object_from_json_str
 from utilities.azure import get_azure_blob_public_url
@@ -52,7 +53,7 @@ def check_index_registration_fields(dataset: dict, dataset_index_item: dict):
     assert dataset_index_item["licence_id"] == dataset["licence_id"]
 
 
-def check_index_most_recent_fields(context: dict, field_grouping: str, dataset: dict, dataset_index_item: dict):
+def check_index_most_recent_fields(context: BDSContext, field_grouping: str, dataset: dict, dataset_index_item: dict):
     field_group = "most_recent_{}_attempt".format(field_grouping)
     assert field_group in dataset_index_item
     assert dataset_index_item[field_group]["datetime"] == get_datetime_as_str_or_none(dataset["{}_datetime".format(field_group)])
@@ -60,7 +61,7 @@ def check_index_most_recent_fields(context: dict, field_grouping: str, dataset: 
     assert dataset_index_item[field_group]["error_details"] == get_object_from_json_str(dataset["{}_error_details".format(field_group)])
 
 
-def check_index_last_known_good_fields(context: dict, dataset: dict, dataset_index_item: dict):
+def check_index_last_known_good_fields(context: BDSContext, dataset: dict, dataset_index_item: dict):
     assert "last_known_good_dataset" in dataset_index_item
     assert dataset_index_item["last_known_good_dataset"]["downloaded"] == get_datetime_as_str_or_none(dataset["last_known_good_dataset_downloaded"])
     assert dataset_index_item["last_known_good_dataset"]["verified_on_server"] == get_datetime_as_str_or_none(dataset["last_known_good_dataset_verified_on_server"])

--- a/tests/helpers/helpers.py
+++ b/tests/helpers/helpers.py
@@ -6,7 +6,7 @@ import shutil
 import zipfile
 from typing import Any
 from unittest import mock
-
+from config.bds_context import BDSContext
 import pytest
 from azure.storage.blob import BlobServiceClient
 from dotenv import dotenv_values
@@ -36,7 +36,7 @@ def get_number_xml_files_in_working_dir(context):
                          recursive=True))
 
 
-def truncate_db_tables(context: dict):
+def truncate_db_tables(context: BDSContext):
     connection = get_db_connection(context)
     cursor = connection.cursor()
     cursor.execute("""TRUNCATE table iati_reporting_orgs CASCADE""")
@@ -50,7 +50,7 @@ def get_file_contents(filename: str) -> bytes:
         return f.read()
 
 
-def download_dataset_from_azure(context: dict, dataset: dict, type: str) -> bytes:
+def download_dataset_from_azure(context: BDSContext, dataset: dict, type: str) -> bytes:
     blob_service_client = BlobServiceClient.from_connection_string(context["AZURE_STORAGE_CONNECTION_STRING"])
     container_name = get_azure_container_name(context, "zip")
     blob_name = get_azure_blob_name(dataset, type)
@@ -60,7 +60,7 @@ def download_dataset_from_azure(context: dict, dataset: dict, type: str) -> byte
     return blob_as_bytes
 
 
-def download_index_from_azure(context: dict, index_name: str) -> Any:
+def download_index_from_azure(context: BDSContext, index_name: str) -> Any:
     blob_service_client = BlobServiceClient.from_connection_string(context["AZURE_STORAGE_CONNECTION_STRING"])
     zip_container_name = get_azure_container_name(context, "zip")
     index_blob = blob_service_client.get_blob_client(zip_container_name, index_name)
@@ -72,18 +72,20 @@ def download_index_from_azure(context: dict, index_name: str) -> Any:
 @pytest.fixture
 def get_and_clear_up_context():
     logger = mock.Mock()
-    context = dotenv_values("tests-local-environment/.env") | {
+    config = dotenv_values("tests-local-environment/.env") | {
             "logger" : logger,
             "single_run": True,
             "run_for_n_datasets": None,
             "prom_metrics": {}
         }
 
-    context["BULK_DATA_SERVICE_VERSION"] = get_app_version()
-    context["AZURE_SERVICE_BUS_WAIT_TIME"] = 0.1  # type: ignore
+    config["BULK_DATA_SERVICE_VERSION"] = get_app_version()
+    config["AZURE_SERVICE_BUS_WAIT_TIME"] = 0.1  # type: ignore
 
     for metric in get_metrics_definitions():
-        context["prom_metrics"][metric[0]] = mock.Mock()  # type: ignore
+        config["prom_metrics"][metric[0]] = mock.Mock()  # type: ignore
+
+    context = BDSContext(config, logger)
 
     create_azure_blob_containers(context)
     apply_db_migrations(context)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,13 +1,13 @@
 from dotenv import load_dotenv
 
-from config.config import get_config
+from config.config import get_basic_config
 
 
 def test_config_blob_storage_base_url_has_no_trailing_slash_1():
 
     load_dotenv("tests/artifacts/config-files/env-file-1", override=True)
 
-    config = get_config()
+    config = get_basic_config()
 
     assert config["WEB_BASE_URL"] == 'http://127.0.0.1:10000/devstoreaccount1'
 
@@ -16,6 +16,6 @@ def test_config_blob_storage_base_url_has_no_trailing_slash_2():
 
     load_dotenv("tests/artifacts/config-files/env-file-2", override=True)
 
-    config = get_config()
+    config = get_basic_config()
 
     assert config["WEB_BASE_URL"] == 'http://127.0.0.1:10000/devstoreaccount1'


### PR DESCRIPTION
This PR is for a refactor which replaces the app's context `dict` object  with a custom configuration class.

The rationale: previously the app config had been almost all strings, except the logger. As we add more non-string objects to the app config dict, it decreases the usefulness of type hints and IntelliSense/IDE completion. The next PR is going to require more non-string objects being added to the context, so in preparation the config object has been converted to a custom class that inherits from `UserDict` so as to allow all existing functionality for configuration strings to remain the same, but that facilitates arbitrary typed objects as well. The logger has been converted to a such property.

Since the app config/context object is passed around the whole app, this PR affects a lot of files, but almost all the changes involve replacing `context: dict` with `context: BDSConfig` and adding an additional `import` to the top of each file.