### PR TITLE
Fix and improve bulk ZIP creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Added a verify ZIP stage which attempts to unzip the entire ZIP file, and if
+  that fails, it forces a full re-download of all the XML files and then
+  re-attempts the creation of the ZIP.
+
 ### Changed
 
+- To verify the ZIP we have to extract it all. This requires a lot of space, and
+  it means we can no longer just leave the XML files for building the ZIP on
+  disk in between runs, because Azure Container Instances only give ~50 Gb of
+  disk space, and it's not configurable. So, the XML files for each of the ZIP
+  files and the ZIP files themselves are now removed from disk after being
+  uploaded to Azure. But this has meant the automated tests can't just inspect
+  these folders to check they contain the correct content - the automated tests
+  now need to download the appropriate ZIP and unpack it. This is why there are
+  changes to all the ZIP tests.
+
 ### Fixed
+
+- Fixed an issue whereby when an update was made to the dataset's shortname,
+  the dataset was not being updated in the ZIP with the new name.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The `.env` file is used when running things locally to store environment variabl
 Running the app successfully requires a Postgres database and a connection to an Azure blob storage account. There is a docker compose setup which can be used to start an instance of each service locally, that can be run with:
 
 ```
-docker compose up
+docker compose up -d
 ```
 
 The example `.env` file (`.env-example`) is configured to use the above docker compose setup. If you don't use the docker compose setup, then you will need to change the values in the `.env` file accordingly.
@@ -80,6 +80,15 @@ dotenv run python src/iati_bulk_data_service.py -- --operation zipper --single-r
 ```
 
 It will store the ZIP files in the directory defined in the `ZIP_WORKING_DIR` environment variable.
+
+To shutdown the docker compose setup, use (the Azure Service Bus emulator
+appears to be a bit sensitive to Ctrl-C shutdowns, so always best to shutdown
+with `docker compose down`):
+
+```
+docker compose down
+```
+
 
 _Note: not all versions of `dotenv` require a `run` subcommand._
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bulk-data-service"
-version = "1.3.3"
+version = "1.3.4"
 requires-python = ">= 3.12.6"
 readme = "README.md"
 dependencies = [
@@ -50,7 +50,6 @@ filterwarnings = [
     "ignore::DeprecationWarning:yoyo.*:",  # ignore deprecations from all modules
     "default::DeprecationWarning:bulk_data_service.*:",  # except the app
 ]
-
 
 [tool.isort]
 py_version=312

--- a/src/bulk_data_service/dataset_updater.py
+++ b/src/bulk_data_service/dataset_updater.py
@@ -109,9 +109,11 @@ def add_or_update_registered_dataset(
         bds_dataset = create_dataset_from_registered_dataset(registered_datasets[registered_dataset_id])
         old_source_url = ""
         datasets_in_bds[registered_dataset_id] = bds_dataset
+        operation = "Added"
     else:
         bds_dataset = datasets_in_bds[registered_dataset_id]
         old_source_url = bds_dataset["source_url"]
+        operation = "Updated"
         update_dataset_from_registered_dataset(bds_dataset, registered_datasets[registered_dataset_id])
 
     check_time = get_timestamp()
@@ -135,7 +137,7 @@ def add_or_update_registered_dataset(
 
             datasets_in_bds[registered_dataset_id] = bds_dataset
 
-            context.logger.info("dataset id: {} - Added/updated dataset".format(bds_dataset["id"]))
+            context.logger.info("dataset id: {} - {} dataset".format(bds_dataset["id"], operation))
 
         except RuntimeError as e:
             summary_message = "Download of IATI XML failed with non-200 HTTP status"

--- a/src/bulk_data_service/zipper.py
+++ b/src/bulk_data_service/zipper.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import pathlib
 import shutil
 import time
 import uuid
@@ -50,7 +51,7 @@ def zipper_run(
     run_start = datetime.datetime.now(datetime.UTC)
     context.logger.info("Zipper run starting")
 
-    setup_working_dir_with_downloaded_datasets(context, datasets_in_working_dir, datasets_in_bds)
+    setup_working_dir_with_downloaded_datasets(context, False, datasets_in_working_dir, datasets_in_bds)
 
     zip_creators = [
         IATIBulkDataServiceZipper(
@@ -71,15 +72,26 @@ def zipper_run(
 
     for zip_creator in zip_creators:
 
-        if os.path.exists(zip_creator.zip_working_dir):
-            shutil.rmtree(zip_creator.zip_working_dir)
-        shutil.copytree(context["ZIP_WORKING_DIR"], zip_creator.zip_working_dir)
+        for _ in range(2):
+            zip_creator.clean_working_dir()
 
-        zip_creator.prepare()
+            shutil.copytree(context["ZIP_WORKING_DIR"], zip_creator.zip_working_dir)
 
-        zip_creator.zip()
+            zip_creator.prepare()
 
-        zip_creator.upload()
+            zip_creator.zip()
+
+            if zip_creator.valid_zip_created():
+                zip_creator.upload()
+                break
+            else:
+                context.logger.error("Zip validation failed so resetting working directory and re-trying")
+                setup_working_dir_with_downloaded_datasets(context, True, datasets_in_working_dir, datasets_in_bds)
+
+        # Whether ZIP was successfully created and uploaded or not, we wipe the working dir for this ZIP format
+        # We have to do this because now that we verify the ZIP by unpacking it, more storage is needed, but ACI
+        # temporary disks are not configurable and max out at 50 Gb.
+        zip_creator.clean_working_dir()
 
     run_end = datetime.datetime.now(datetime.UTC)
     context.logger.info("Zipper run finished in {}.".format(run_end - run_start))
@@ -87,10 +99,13 @@ def zipper_run(
 
 
 def setup_working_dir_with_downloaded_datasets(
-    context: BDSContext, datasets_in_working_dir: dict[uuid.UUID, dict], datasets_in_bds: dict[uuid.UUID, dict]
+    context: BDSContext,
+    force_full_clean: bool,
+    datasets_in_working_dir: dict[uuid.UUID, dict],
+    datasets_in_bds: dict[uuid.UUID, dict],
 ):
 
-    clean_working_dir(context, datasets_in_working_dir)
+    clean_working_dir(context, force_full_clean, datasets_in_working_dir, datasets_in_bds)
 
     datasets_with_downloads = {k: v for k, v in datasets_in_bds.items() if dataset_has_iati_xml_download(v)}
 
@@ -102,6 +117,7 @@ def setup_working_dir_with_downloaded_datasets(
         if k not in datasets_in_working_dir
         or datasets_in_working_dir[k]["last_known_good_dataset_hash"]
         != datasets_with_downloads[k]["last_known_good_dataset_hash"]
+        or datasets_in_working_dir[k]["short_name"] != datasets_with_downloads[k]["short_name"]
     }
 
     context.logger.info(
@@ -114,13 +130,38 @@ def setup_working_dir_with_downloaded_datasets(
     download_new_or_updated_to_working_dir(context, new_or_updated_datasets)
 
     datasets_in_working_dir.clear()
-    datasets_in_working_dir.update(datasets_with_downloads)
+    for k, dataset in datasets_with_downloads.items():
+        datasets_in_working_dir[k] = dataset.copy()
 
 
-def clean_working_dir(context: BDSContext, datasets_in_zip: dict[uuid.UUID, dict]):
-    if len(datasets_in_zip) == 0:
-        context.logger.info("First zip run of session, so deleting all XML " "files in the ZIP working dir.")
+def clean_working_dir(
+    context: BDSContext,
+    force_full_clean: bool,
+    datasets_in_zip: dict[uuid.UUID, dict],
+    datasets_in_bds: dict[uuid.UUID, dict],
+) -> None:
+    if len(datasets_in_zip) == 0 or force_full_clean:
+        if len(datasets_in_zip) == 0:
+            context.logger.info("First zip run of session, so deleting all XML files in the ZIP working dir.")
+        else:
+            context.logger.info("Force clean requested, so deleting all XML files in the ZIP working dir.")
         shutil.rmtree("{}/{}".format(context["ZIP_WORKING_DIR"], "iati-data"), ignore_errors=True)
+    else:
+        context.logger.info("Zipper: removing deleted or renamed datasets from working directory")
+
+        ds_partial_paths = [
+            dataset["reporting_org_short_name"] + "/" + dataset["short_name"] for dataset in datasets_in_bds.values()
+        ]
+
+        path_datasets = pathlib.Path(os.path.join(context["ZIP_WORKING_DIR"], "iati-data", "datasets"))
+
+        for file in path_datasets.glob("**/*.xml"):
+            dataset_partial_path = file.parts[-2] + "/" + file.stem
+            if dataset_partial_path not in ds_partial_paths:
+                try:
+                    os.remove(str(file))
+                except (FileNotFoundError, PermissionError, IsADirectoryError, OSError) as e:
+                    context.logger.error(f"Zipper: error removing XML file {file} from working directory: {e}")
 
 
 def remove_datasets_without_dls_from_working_dir(

--- a/src/bulk_data_service/zippers.py
+++ b/src/bulk_data_service/zippers.py
@@ -2,6 +2,7 @@ import json
 import os
 import shutil
 import uuid
+import zipfile
 from abc import ABC, abstractmethod
 
 from azure.storage.blob import BlobServiceClient
@@ -49,6 +50,10 @@ class IATIDataZipper(ABC):
     def zip_local_filename_no_extension(self) -> str:
         return "iati-data"
 
+    def clean_working_dir(self):
+        if os.path.exists(self.zip_working_dir):
+            shutil.rmtree(self.zip_working_dir)
+
     def zip(self):
         self.context.logger.info("Zipping {} datasets.".format(get_number_xml_files_in_dir(self.zip_working_dir)))
         shutil.make_archive(
@@ -57,6 +62,17 @@ class IATIDataZipper(ABC):
             root_dir=self.zip_working_dir,
             base_dir=self.zip_internal_directory_name,
         )
+
+    def valid_zip_created(self) -> bool:
+        self.context.logger.info("Verifying ZIP file {}.zip".format(self.get_zip_local_pathname_no_extension()))
+        with zipfile.ZipFile(self.get_zip_local_pathname(), "r") as zf:
+            try:
+                zf.extractall(os.path.join(self.zip_working_dir, "verifyzip"))
+            except zipfile.BadZipFile:
+                shutil.rmtree(os.path.join(self.zip_working_dir, "verifyzip"))
+                return False
+        shutil.rmtree(os.path.join(self.zip_working_dir, "verifyzip"))
+        return True
 
     def upload(self):
         self.context.logger.info(

--- a/src/utilities/azure.py
+++ b/src/utilities/azure.py
@@ -103,7 +103,7 @@ def create_azure_blob_containers(context: BDSContext):
 
     try:
         if context["AZURE_STORAGE_BLOB_CONTAINER_NAME"] not in container_names:
-            blob_service.create_container(context["AZURE_STORAGE_BLOB_CONTAINER_NAME"])
+            blob_service.create_container(context["AZURE_STORAGE_BLOB_CONTAINER_NAME"], public_access="blob")
             container_names.append(context["AZURE_STORAGE_BLOB_CONTAINER_NAME"])
     except Exception as e:
         context.logger.error(

--- a/tests-local-environment/.env
+++ b/tests-local-environment/.env
@@ -51,5 +51,5 @@ AZURE_SERVICE_BUS_CONNECTION_STRING="Endpoint=sb://localhost:5673;SharedAccessKe
 AZURE_SERVICE_BUS_REGISTRY_TOPIC_NAME="iati-mq-registry-changes-topic-local"
 AZURE_SERVICE_BUS_REGISTRY_SUB_NAME="iati-mq-registry-changes-sub-local"
 AZURE_SERVICE_BUS_DATASET_CHECK_RESULTS_TOPIC_NAME="iati-mq-dataset-check-results-topic-local"
-AZURE_SERVICE_BUS_WAIT_TIME=0.1
+AZURE_SERVICE_BUS_WAIT_TIME=0.5
 

--- a/tests/artifacts/ckan-registry-responses/datasets-06-1-dataset-updated-metadata.json
+++ b/tests/artifacts/ckan-registry-responses/datasets-06-1-dataset-updated-metadata.json
@@ -1,0 +1,115 @@
+{
+    "help": "https://iatiregistry.org/api/3/action/help_show?name=package_search",
+    "success": true,
+    "result": {
+        "count": 1,
+        "facets": {},
+        "results": [
+            {
+                "author": null,
+                "author_email": "publisher@email-here-updated.com",
+                "creator_user_id": "4abc4897-94b7-4b0e-84c2-c8778f435ccb",
+                "id": "c8a40aa5-9f31-4bcf-a36f-51c1fc2cc159",
+                "isopen": true,
+                "license_id": "uk-ogl",
+                "license_title": "Other (Attribution)",
+                "maintainer": null,
+                "maintainer_email": null,
+                "metadata_created": "2024-03-04T10:24:11.373108",
+                "metadata_modified": "2024-05-07T15:38:58.740018",
+                "name": "test_foundation_a-dataset-001-newname",
+                "notes": "",
+                "num_resources": 1,
+                "num_tags": 0,
+                "organization": {
+                    "id": "ea055d99-f7e9-456f-9f99-963e95493c1b",
+                    "name": "test_foundation_a",
+                    "title": "Test Foundation A",
+                    "type": "organization",
+                    "description": "",
+                    "image_url": "",
+                    "created": "2020-02-24T20:56:01.763851",
+                    "is_organization": true,
+                    "approval_status": "approved",
+                    "state": "active"
+                },
+                "owner_org": "5d04f169-c702-45fe-8162-da7834859d86",
+                "private": false,
+                "state": "active",
+                "title": "040324",
+                "type": "dataset",
+                "url": null,
+                "version": null,
+                "extras": [
+                    {
+                        "key": "activity_count",
+                        "value": "10"
+                    },
+                    {
+                        "key": "country",
+                        "value": "GB"
+                    },
+                    {
+                        "key": "data_updated",
+                        "value": "2024-03-01 14:24:09"
+                    },
+                    {
+                        "key": "filetype",
+                        "value": "activity"
+                    },
+                    {
+                        "key": "iati_version",
+                        "value": "2.03"
+                    },
+                    {
+                        "key": "language",
+                        "value": ""
+                    },
+                    {
+                        "key": "secondary_publisher",
+                        "value": ""
+                    },
+                    {
+                        "key": "validation_status",
+                        "value": "Not Found"
+                    }
+                ],
+                "resources": [
+                    {
+                        "cache_last_updated": null,
+                        "cache_url": null,
+                        "created": "2024-05-07T15:38:57.312249",
+                        "description": null,
+                        "format": "IATI-XML",
+                        "hash": "f6bb14d61bb2652f1014d6ebfee3c4b873241bac",
+                        "id": "d1b3d323-c8ba-48c5-89ce-6e745241d7fe",
+                        "last_modified": null,
+                        "metadata_modified": "2024-05-07T15:38:58.757860",
+                        "mimetype": "",
+                        "mimetype_inner": null,
+                        "name": null,
+                        "package_id": "b83ebe89-d522-4d3b-87e9-53aa9ac8eee9",
+                        "position": 0,
+                        "resource_type": null,
+                        "size": 399382,
+                        "state": "active",
+                        "url": 
+                                {{#if (urlParam 'source_url')}}
+                                    "{{urlParam 'source_url'}}"
+                                {{else}}
+                                    "http://localhost:3000/data/test_foundation_a-dataset-001.xml"
+                                {{/if}}
+                                ,
+                        "url_type": null
+                    }
+                ],
+                "tags": [],
+                "groups": [],
+                "relationships_as_subject": [],
+                "relationships_as_object": []
+            }
+        ],
+        "sort": "title_string asc",
+        "search_facets": {}
+    }
+}

--- a/tests/artifacts/iati-xml-files/test_foundation_a-dataset-001-updated.xml
+++ b/tests/artifacts/iati-xml-files/test_foundation_a-dataset-001-updated.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iati-activities version="2.03" generated-datetime="2024-05-03T08:47:49+00:00">
+  <iati-activity>
+    <iati-identifier>AA-AAA-123456789-ABC123</iati-identifier>
+    <reporting-org ref="" type="">
+      <narrative></narrative>
+    </reporting-org>
+    <title>
+      <narrative>An activity with a title - UPDATED</narrative>
+    </title>
+    <description>
+      <narrative></narrative>
+    </description>
+    <participating-org role="">
+    </participating-org>
+    <activity-status code="">
+    </activity-status>
+    <activity-date type="" iso-date="2018-01-01">
+    </activity-date>
+  </iati-activity>
+  <iati-activity>
+    <iati-identifier>AA-AAA-123456789-ABC456</iati-identifier>
+    <reporting-org ref="" type="">
+      <narrative></narrative>
+    </reporting-org>
+    <title>
+      <narrative>An activity with a title - UPDATED</narrative>
+    </title>
+    <description>
+      <narrative></narrative>
+    </description>
+    <participating-org role="">
+    </participating-org>
+    <activity-status code="">
+    </activity-status>
+    <activity-date type="" iso-date="2018-01-01">
+    </activity-date>
+  </iati-activity>
+</iati-activities>

--- a/tests/helpers/helpers.py
+++ b/tests/helpers/helpers.py
@@ -86,6 +86,13 @@ def get_and_clear_up_context():
 
     context = BDSContext(config, logger, mock.create_autospec(IServiceFactory))
 
+    context["TEST_TMP_ZIP_UNPACK"] = "tests/tmp_zip_unpack"
+
+    if os.path.exists(context["TEST_TMP_ZIP_UNPACK"]):
+        shutil.rmtree(context["TEST_TMP_ZIP_UNPACK"])
+
+    os.makedirs(context["TEST_TMP_ZIP_UNPACK"], exist_ok=True)
+
     create_azure_blob_containers(context)
     apply_db_migrations(context)
     yield context
@@ -97,3 +104,6 @@ def get_and_clear_up_context():
         for zip_dir in zip_dirs:
             if os.path.exists(zip_dir):
                 shutil.rmtree(zip_dir)
+
+    if os.path.exists(context["TEST_TMP_ZIP_UNPACK"]):
+        shutil.rmtree(context["TEST_TMP_ZIP_UNPACK"])

--- a/tests/integration/test_zip_creation.py
+++ b/tests/integration/test_zip_creation.py
@@ -2,6 +2,9 @@ import json
 import os
 import zipfile
 
+import pytest
+import requests
+
 from bulk_data_service.checker import checker_run
 from bulk_data_service.zipper import zipper_run
 from helpers.helpers import get_and_clear_up_context, get_number_xml_files_in_working_dir  # noqa: F401
@@ -12,7 +15,7 @@ def test_dataset_saved_for_download_success(get_and_clear_up_context):  # noqa: 
 
     context = get_and_clear_up_context
 
-    run_checker_then_zipper_download_ok(context)
+    run_checker_then_zipper_once(context)
 
     assert get_number_xml_files_in_working_dir(context) == 1
     assert os.path.exists("{}{}".format(
@@ -45,9 +48,11 @@ def test_publisher_metadata_saved_for_failed_metadata_dl(get_and_clear_up_contex
 
     context = get_and_clear_up_context
 
-    run_checker_then_zipper_download_ok(context)
+    run_checker_then_zipper_once(context)
 
-    assert os.path.exists(context["ZIP_WORKING_DIR"] + "-2/iati-data-main/metadata/test_foundation_a.json") is True
+    download_and_unpack_zip_to_tmp_unpack_folder(context, "code-for-iati-data-download.zip")
+
+    assert os.path.exists(context["TEST_TMP_ZIP_UNPACK"] + "/iati-data-main/metadata/test_foundation_a.json") is True
 
 
 def test_publisher_metadata_saved_for_successful_metadata_dl(get_and_clear_up_context):  # noqa: F811
@@ -61,7 +66,9 @@ def test_publisher_metadata_saved_for_successful_metadata_dl(get_and_clear_up_co
     datasets_in_zip = {}
     zipper_run(context, datasets_in_zip, datasets_in_bds, get_reporting_orgs_in_bds(context))
 
-    assert os.path.exists(context["ZIP_WORKING_DIR"] + "-2/iati-data-main/metadata/test_foundation_a.json") is True
+    download_and_unpack_zip_to_tmp_unpack_folder(context, "code-for-iati-data-download.zip")
+
+    assert os.path.exists(context["TEST_TMP_ZIP_UNPACK"] + "/iati-data-main/metadata/test_foundation_a.json") is True
 
 
 def test_publisher_metadata_content_for_successful_metadata_dl(get_and_clear_up_context):  # noqa: F811
@@ -75,7 +82,9 @@ def test_publisher_metadata_content_for_successful_metadata_dl(get_and_clear_up_
     datasets_in_zip = {}
     zipper_run(context, datasets_in_zip, datasets_in_bds, get_reporting_orgs_in_bds(context))
 
-    with open(context["ZIP_WORKING_DIR"] + "-2/iati-data-main/metadata/test_foundation_a.json", "r") as f:
+    download_and_unpack_zip_to_tmp_unpack_folder(context, "code-for-iati-data-download.zip")
+
+    with open(context["TEST_TMP_ZIP_UNPACK"] + "/iati-data-main/metadata/test_foundation_a.json", "r") as f:
         assert f.read() == json.dumps(
             {
                 "id": "ea055d99-f7e9-456f-9f99-963e95493c1b",
@@ -95,7 +104,9 @@ def test_dataset_metadata_content_for_successful_metadata_dl(get_and_clear_up_co
     datasets_in_zip = {}
     zipper_run(context, datasets_in_zip, datasets_in_bds, get_reporting_orgs_in_bds(context))
 
-    with open(context["ZIP_WORKING_DIR"] + "-2/iati-data-main/metadata/test_foundation_a/test_foundation_a-dataset-001-newname.json", "r") as f:
+    download_and_unpack_zip_to_tmp_unpack_folder(context, "code-for-iati-data-download.zip")
+
+    with open(context["TEST_TMP_ZIP_UNPACK"] + "/iati-data-main/metadata/test_foundation_a/test_foundation_a-dataset-001-newname.json", "r") as f:
         assert f.read() == json.dumps(
             {
                 "id": "c8a40aa5-9f31-4bcf-a36f-51c1fc2cc159",
@@ -116,20 +127,79 @@ def test_bds_zip_content_for_download_success(get_and_clear_up_context):  # noqa
 
     context = get_and_clear_up_context
 
-    run_checker_then_zipper_download_ok(context)
+    run_checker_then_zipper_once(context)
 
-    bds_zip_filename = context["ZIP_WORKING_DIR"] + "-1/iati-data.zip"
+    download_and_unpack_zip_to_tmp_unpack_folder(context)
 
-    assert os.path.exists(bds_zip_filename) is True
+    assert file_found_in_extracted_zip(context, "iati-data/datasets-minimal.json")
+    assert file_found_in_extracted_zip(context, "iati-data/datasets-full.json")
+    assert file_found_in_extracted_zip(context, "iati-data/reporting-orgs.json")
+    assert file_found_in_extracted_zip(context, "iati-data/datasets/test_foundation_a/test_foundation_a-dataset-001.xml")
 
-    bds_zip_file = zipfile.ZipFile(bds_zip_filename)
 
-    filelist = bds_zip_file.namelist()
+def test_bds_zip_content_for_download_success_dataset_updated_meta(get_and_clear_up_context, tmp_path):  # noqa: F811
+    """Checks that when a dataset's short_name is altered, the dataset is found in the ZIP with new but not old name"""
 
-    assert ("iati-data/datasets-minimal.json" in filelist) is True
-    assert ("iati-data/datasets-full.json" in filelist) is True
-    assert ("iati-data/reporting-orgs.json" in filelist) is True
-    assert ("iati-data/datasets/test_foundation_a/test_foundation_a-dataset-001.xml" in filelist) is True
+    context = get_and_clear_up_context
+
+    datasets_in_bds = {}
+    datasets_in_zip = {}
+
+    run_checker_then_zipper(
+        context, "http://localhost:3000/ckan-registration/datasets-01-1-dataset", datasets_in_bds, datasets_in_zip
+    )
+
+    run_checker_then_zipper(
+        context,
+        "http://localhost:3000/ckan-registration/datasets-06-1-dataset-updated-metadata",
+        datasets_in_bds,
+        datasets_in_zip,
+    )
+
+    download_and_unpack_zip_to_tmp_unpack_folder(context)
+
+    assert file_found_in_extracted_zip(context, "iati-data/datasets-minimal.json")
+    assert file_found_in_extracted_zip(context, "iati-data/datasets-full.json")
+    assert file_found_in_extracted_zip(context, "iati-data/reporting-orgs.json")
+    assert file_found_in_extracted_zip(context, "iati-data/datasets/test_foundation_a/test_foundation_a-dataset-001-newname.xml")
+
+    # The dataset as it was originally named should not be found
+    assert not file_found_in_extracted_zip(context, "iati-data/datasets/test_foundation_a/test_foundation_a-dataset-001.xml")
+
+
+def test_bds_zip_content_for_download_success_dataset_updated_content(get_and_clear_up_context):  # noqa: F811
+    """Checks that when dataset contents (but not metadata) is updated the new file contents is found in the ZIP"""
+
+    context = get_and_clear_up_context
+
+    datasets_in_bds = {}
+    datasets_in_zip = {}
+
+    run_checker_then_zipper(
+        context, "http://localhost:3000/ckan-registration/datasets-01-1-dataset", datasets_in_bds, datasets_in_zip
+    )
+
+    run_checker_then_zipper(
+        context,
+        (
+            "http://localhost:3000/ckan-registration/datasets-01-1-dataset/"
+            "http%3A%2F%2Flocalhost%3A3000%2Fdata%2Ftest_foundation_a-dataset-001-updated.xml"
+        ),
+        datasets_in_bds,
+        datasets_in_zip,
+    )
+
+    download_and_unpack_zip_to_tmp_unpack_folder(context)
+
+    assert file_found_in_extracted_zip(context, "iati-data/datasets-minimal.json")
+
+    with open(os.path.join(context["TEST_TMP_ZIP_UNPACK"], "iati-data/datasets/test_foundation_a/test_foundation_a-dataset-001.xml"), "rb") as f:
+        contents_from_zip = f.read()
+
+    with open("tests/artifacts/iati-xml-files/test_foundation_a-dataset-001-updated.xml", "rb") as f:
+        contents_from_disk = f.read()
+
+    assert contents_from_disk == contents_from_zip
 
 
 def test_bds_zip_content_for_download_fail_but_cached(get_and_clear_up_context):  # noqa: F811
@@ -138,18 +208,12 @@ def test_bds_zip_content_for_download_fail_but_cached(get_and_clear_up_context):
 
     run_checker_then_zipper_download_fail_but_cached(context)
 
-    bds_zip_filename = context["ZIP_WORKING_DIR"] + "-1/iati-data.zip"
+    download_and_unpack_zip_to_tmp_unpack_folder(context)
 
-    assert os.path.exists(bds_zip_filename) is True
-
-    bds_zip_file = zipfile.ZipFile(bds_zip_filename)
-
-    filelist = bds_zip_file.namelist()
-
-    assert ("iati-data/datasets-minimal.json" in filelist) is True
-    assert ("iati-data/datasets-full.json" in filelist) is True
-    assert ("iati-data/reporting-orgs.json" in filelist) is True
-    assert ("iati-data/datasets/test_foundation_a/test_foundation_a-dataset-001.xml" in filelist) is True
+    assert file_found_in_extracted_zip(context, "iati-data/datasets-minimal.json")
+    assert file_found_in_extracted_zip(context, "iati-data/datasets-full.json")
+    assert file_found_in_extracted_zip(context, "iati-data/reporting-orgs.json")
+    assert file_found_in_extracted_zip(context, "iati-data/datasets/test_foundation_a/test_foundation_a-dataset-001.xml")
 
 
 def test_bds_zip_content_for_download_fail_no_cached(get_and_clear_up_context):  # noqa: F811
@@ -158,41 +222,29 @@ def test_bds_zip_content_for_download_fail_no_cached(get_and_clear_up_context): 
 
     run_checker_then_zipper_download_fail(context)
 
-    bds_zip_filename = context["ZIP_WORKING_DIR"] + "-1/iati-data.zip"
+    download_and_unpack_zip_to_tmp_unpack_folder(context)
 
-    assert os.path.exists(bds_zip_filename) is True
-
-    bds_zip_file = zipfile.ZipFile(bds_zip_filename)
-
-    filelist = bds_zip_file.namelist()
-
-    assert ("iati-data/datasets-minimal.json" in filelist) is True
-    assert ("iati-data/datasets-full.json" in filelist) is True
-    assert ("iati-data/reporting-orgs.json" in filelist) is True
-    assert ("iati-data/datasets/test_foundation_a/test_foundation_a-dataset-001.xml" in filelist) is False
+    assert file_found_in_extracted_zip(context, "iati-data/datasets-minimal.json")
+    assert file_found_in_extracted_zip(context, "iati-data/datasets-full.json")
+    assert file_found_in_extracted_zip(context, "iati-data/reporting-orgs.json")
+    assert not file_found_in_extracted_zip(context, "iati-data/datasets/test_foundation_a/test_foundation_a-dataset-001.xml")
 
 
 def test_codeforiati_zip_content_for_download_success(get_and_clear_up_context):  # noqa: F811
 
     context = get_and_clear_up_context
 
-    run_checker_then_zipper_download_ok(context)
+    run_checker_then_zipper_once(context)
 
-    bds_zip_filename = context["ZIP_WORKING_DIR"] + "-2/code-for-iati-data-download.zip"
+    download_and_unpack_zip_to_tmp_unpack_folder(context, "code-for-iati-data-download.zip")
 
-    assert os.path.exists(bds_zip_filename) is True
-
-    bds_zip_file = zipfile.ZipFile(bds_zip_filename)
-
-    filelist = bds_zip_file.namelist()
-
-    assert ("iati-data/datasets-minimal.json" in filelist) is False
-    assert ("iati-data/datasets-full.json" in filelist) is False
-    assert ("iati-data/reporting-orgs.json" in filelist) is False
-    assert ("iati-data-main/metadata.json" in filelist) is True
-    assert ("iati-data-main/data/test_foundation_a/test_foundation_a-dataset-001.xml" in filelist) is True
-    assert ("iati-data-main/metadata/test_foundation_a.json" in filelist) is True
-    assert ("iati-data-main/metadata/test_foundation_a/test_foundation_a-dataset-001.json" in filelist) is True
+    assert not file_found_in_extracted_zip(context, "iati-data/datasets-minimal.json")
+    assert not file_found_in_extracted_zip(context, "iati-data/datasets-full.json")
+    assert not file_found_in_extracted_zip(context, "iati-data/reporting-orgs.json")
+    assert file_found_in_extracted_zip(context, "iati-data-main/metadata.json")
+    assert file_found_in_extracted_zip(context, "iati-data-main/data/test_foundation_a/test_foundation_a-dataset-001.xml")
+    assert file_found_in_extracted_zip(context, "iati-data-main/metadata/test_foundation_a.json")
+    assert file_found_in_extracted_zip(context, "iati-data-main/metadata/test_foundation_a/test_foundation_a-dataset-001.json")
 
 
 def test_codeforiati_zip_content_for_download_fail_but_cached(get_and_clear_up_context):  # noqa: F811
@@ -201,21 +253,15 @@ def test_codeforiati_zip_content_for_download_fail_but_cached(get_and_clear_up_c
 
     run_checker_then_zipper_download_fail_but_cached(context)
 
-    bds_zip_filename = context["ZIP_WORKING_DIR"] + "-2/code-for-iati-data-download.zip"
+    download_and_unpack_zip_to_tmp_unpack_folder(context, "code-for-iati-data-download.zip")
 
-    assert os.path.exists(bds_zip_filename) is True
-
-    bds_zip_file = zipfile.ZipFile(bds_zip_filename)
-
-    filelist = bds_zip_file.namelist()
-
-    assert ("iati-data/datasets-minimal.json" in filelist) is False
-    assert ("iati-data/datasets-full.json" in filelist) is False
-    assert ("iati-data/reporting-orgs.json" in filelist) is False
-    assert ("iati-data-main/metadata.json" in filelist) is True
-    assert ("iati-data-main/data/test_foundation_a/test_foundation_a-dataset-001.xml" in filelist) is True
-    assert ("iati-data-main/metadata/test_foundation_a.json" in filelist) is True
-    assert ("iati-data-main/metadata/test_foundation_a/test_foundation_a-dataset-001.json" in filelist) is True
+    assert not file_found_in_extracted_zip(context, "iati-data/datasets-minimal.json")
+    assert not file_found_in_extracted_zip(context, "iati-data/datasets-full.json")
+    assert not file_found_in_extracted_zip(context, "iati-data/reporting-orgs.json")
+    assert file_found_in_extracted_zip(context, "iati-data-main/metadata.json")
+    assert file_found_in_extracted_zip(context, "iati-data-main/data/test_foundation_a/test_foundation_a-dataset-001.xml")
+    assert file_found_in_extracted_zip(context, "iati-data-main/metadata/test_foundation_a.json")
+    assert file_found_in_extracted_zip(context, "iati-data-main/metadata/test_foundation_a/test_foundation_a-dataset-001.json")
 
 
 def test_codeforiati_zip_content_for_download_fail_no_cached(get_and_clear_up_context):  # noqa: F811
@@ -224,29 +270,29 @@ def test_codeforiati_zip_content_for_download_fail_no_cached(get_and_clear_up_co
 
     run_checker_then_zipper_download_fail(context)
 
-    bds_zip_filename = context["ZIP_WORKING_DIR"] + "-2/code-for-iati-data-download.zip"
+    download_and_unpack_zip_to_tmp_unpack_folder(context, "code-for-iati-data-download.zip")
 
-    assert os.path.exists(bds_zip_filename) is True
+    assert not file_found_in_extracted_zip(context, "iati-data/datasets-minimal.json")
+    assert not file_found_in_extracted_zip(context, "iati-data/datasets-full.json")
+    assert not file_found_in_extracted_zip(context, "iati-data/reporting-orgs.json")
+    assert file_found_in_extracted_zip(context, "iati-data-main/metadata.json")
+    assert file_found_in_extracted_zip(context, "iati-data-main/data/test_foundation_a/test_foundation_a-dataset-001.xml")
+    assert file_found_in_extracted_zip(context, "iati-data-main/metadata/test_foundation_a.json")
+    assert file_found_in_extracted_zip(context, "iati-data-main/metadata/test_foundation_a/test_foundation_a-dataset-001.json")
 
-    bds_zip_file = zipfile.ZipFile(bds_zip_filename)
-
-    fileinfolist = bds_zip_file.infolist()
-    filelist = [fileinfo.filename for fileinfo in fileinfolist]
-
-    assert ("iati-data/datasets-minimal.json" in filelist) is False
-    assert ("iati-data/datasets-full.json" in filelist) is False
-    assert ("iati-data/reporting-orgs.json" in filelist) is False
-    assert ("iati-data-main/metadata.json" in filelist) is True
-    assert ("iati-data-main/data/test_foundation_a/test_foundation_a-dataset-001.xml" in filelist) is True
-    assert ("iati-data-main/metadata/test_foundation_a.json" in filelist) is True
-    assert ("iati-data-main/metadata/test_foundation_a/test_foundation_a-dataset-001.json" in filelist) is True
-
-    fileinfoxml = list(filter(lambda f: f.filename == "iati-data-main/data/test_foundation_a/test_foundation_a-dataset-001.xml", fileinfolist))[0]
-    assert fileinfoxml.file_size == 0
+    assert os.path.getsize(os.path.join(context["TEST_TMP_ZIP_UNPACK"], "iati-data-main/data/test_foundation_a/test_foundation_a-dataset-001.xml")) == 0
 
 
-def run_checker_then_zipper_download_ok(context):
-    context["DATA_REGISTRY_BASE_URL"] = "http://localhost:3000/ckan-registration/datasets-01-1-dataset"
+def run_checker_then_zipper(context, registry_url: str, datasets_in_bds: dict, datasets_in_zip: dict):
+    context["DATA_REGISTRY_BASE_URL"] = registry_url
+    checker_run(context, datasets_in_bds)
+    zipper_run(context, datasets_in_zip, datasets_in_bds, get_reporting_orgs_in_bds(context))
+
+
+def run_checker_then_zipper_once(
+    context, registry_url: str = "http://localhost:3000/ckan-registration/datasets-01-1-dataset"
+):
+    context["DATA_REGISTRY_BASE_URL"] = registry_url
     datasets_in_bds = {}
     checker_run(context, datasets_in_bds)
 
@@ -274,3 +320,20 @@ def run_checker_then_zipper_download_fail_but_cached(context):
 
     datasets_in_zip = {}
     zipper_run(context, datasets_in_zip, datasets_in_bds, get_reporting_orgs_in_bds(context))
+
+
+def download_and_unpack_zip_to_tmp_unpack_folder(context, zip_name: str = "iati-data.zip"):
+    dest_filename = os.path.join(context["TEST_TMP_ZIP_UNPACK"], "downloaded.zip")
+
+    response = requests.get(f"{context["WEB_BASE_URL"]}/{context["AZURE_STORAGE_BLOB_CONTAINER_NAME"]}/{zip_name}")
+    response.raise_for_status()
+
+    with open(dest_filename, "wb") as f:
+        f.write(response.content)
+
+    zf = zipfile.ZipFile(dest_filename)
+    zf.extractall(context["TEST_TMP_ZIP_UNPACK"])
+
+
+def file_found_in_extracted_zip(context, filename: str) -> bool:
+    return os.path.exists(os.path.join(context["TEST_TMP_ZIP_UNPACK"], filename))


### PR DESCRIPTION
This PR does two things, both related to the creation of the bulk ZIP files.

First, it fixes issue #112 whereby some datasets that were being updated were not being updated in the bulk ZIP file. (For example, when the dataset short name was updated, the dataset was not updated in the ZIP file, so it retained the old name).

Second, to try to address #110, the code now attempts to verify the integrity of the ZIP file created by unpacking it to disk. If any error is encountered, it wipes the working directory, re-copies the XML files, and tries once more.

This second alteration required changing how the ZIP creation worked. Previously, all the available XML files were downloaded into a main ZIP working directory. Then, for each type of ZIP created, a copy of that directory was taken, where any required modifications to the directory names (e.g., for Code for IATI, `iati-data` -> `iati-data-main`) and any extra metadata files were placed. These directories were then left in place and just updated as needed, to save copying ~20 Gb to/from disk every 20 minutes.

However, Azure Container Instances only provide an ephemeral disk space of max ~50 Gb, and this is not configurable. Given that we now unpack the ZIPs to verify them, these files cannot be left in place. So after each ZIP is created and uploaded to Azure, the working directory for that type of ZIP is cleared, which leaves enough space for the next ZIP creation to verify by unpacking.