### PR TITLE
fix: add git to build for new SuiteCRM library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,34 @@
-FROM python:3.12.6-slim-bookworm
+FROM python:3.12.6-slim-bookworm AS builder
 
-RUN apt-get update -y
+RUN apt-get update && apt-get install -y git
+
+ENV VIRTUAL_ENV=/opt/venv
+
+RUN python3 -m venv $VIRTUAL_ENV
+
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 WORKDIR /bulk-data-service
 
 COPY requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+
+FROM python:3.12.6-slim-bookworm
+
+RUN apt-get update -y
+
+COPY --from=builder /opt/venv /opt/venv
+
+ENV PATH="/opt/venv/bin:$PATH"
+
+WORKDIR /bulk-data-service
+
 COPY pyproject.toml .
 
-RUN pip install -r requirements.txt
-
 COPY src/ src
+
 COPY db-migrations/ db-migrations
 
-ENTRYPOINT ["/usr/local/bin/python", "src/iati_bulk_data_service.py"]
+ENTRYPOINT ["python", "src/iati_bulk_data_service.py"]

--- a/azure-deployment/azure-resource-manager-deployment-template.yml
+++ b/azure-deployment/azure-resource-manager-deployment-template.yml
@@ -23,7 +23,7 @@ properties: # Properties of container group
         ports:
           - port: 9090
         command:
-          - "/usr/local/bin/python"
+          - "python"
           - "src/iati_bulk_data_service.py"
           - "--operation"
           - "checker"


### PR DESCRIPTION
This PR creates a builder image into which git is installed so that when installing dependencies the newly added iati-registry-libsuitecrm (not on PyPI and installed 
direct from GitHub) can be fetched. Dependencies now installed into a venv, 
which is copied to a new image to avoid having git and other tools in the final image.