### PR TITLE
Updated to only pull list of discoverable orgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Removed
 
+## [1.4.1]
+
+### Changed
+
+- Modified so that the BDS only pulls reporting orgs marked as discoverable on
+  the Registry.
+
 ## [1.4.0]
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bulk-data-service"
-version = "1.4.0"
+version = "1.4.1"
 requires-python = ">= 3.12.6"
 readme = "README.md"
 dependencies = [

--- a/src/dataset_registration/iati_registry_suitecrm.py
+++ b/src/dataset_registration/iati_registry_suitecrm.py
@@ -3,7 +3,7 @@ import random
 import uuid
 from datetime import datetime
 
-from libsuitecrm import SuiteCRM  # type: ignore
+from libsuitecrm import Filter, SuiteCRM  # type: ignore
 
 from bulk_data_service.data_validators import (
     validate_suitecrm_record_structure,
@@ -52,8 +52,8 @@ def fetch_datasets_metadata(
         if owning_org is None:
             context.logger.error(
                 f"SuiteCRM dataset id: {record['id']} has reporting org id: "
-                f"{record['attributes'].get('iati_dataset_owner_org_id', '')} but there is no such reporting org. "
-                "Skipping."
+                f"{record['attributes'].get('iati_dataset_owner_org_id', '')} but that reporting org does not exist "
+                "or is not discoverable. Skipping."
             )
             continue
 
@@ -72,7 +72,8 @@ def fetch_reporting_orgs_metadata(context: BDSContext, refresh_timestamp: dateti
 
     context.logger.info("Fetching all reporting orgs using the libsuitecrm library...")
 
-    suitecrm_reporting_org_records = [r for r in crm.get_all_records("Accounts")]
+    filters = Filter().equal("iati_registry_discoverable", "1")
+    suitecrm_reporting_org_records = [r for r in crm.get_all_records("Accounts", filters=filters)]
 
     crm.logout()
 


### PR DESCRIPTION
This PR makes a small modification to filter all reporting orgs on the new `iati_registry_discoverable` field which became available last week.