### PR TITLE
Update website links and text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Removed
 
+## [1.4.3] - 2026-03-10
+
+### Changed
+
+- Updated website to link to docs and to match naming of this service as it
+  appears on other websites.
+- Change name of service in page.
+- Upgraded the design system.
+
+## [1.4.2] - 2025-12-01
+
+### Changed
+
+- Modified so that the BDS only pulls public datasets from the Registry.
+
 ## [1.4.1]
 
 ### Changed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,8 @@ services:
       ACCEPT_EULA: "Y"
       SQL_WAIT_INTERVAL: 3
     depends_on:
-      - bds-local-dev-mq-db
+      bds-local-dev-mq-db:
+        condition: service_healthy
     networks:
       bds-local-dev-net:
         aliases:
@@ -83,6 +84,11 @@ services:
     environment:
       ACCEPT_EULA: "Y"
       MSSQL_SA_PASSWORD: "${AZURE_SERVICE_BUS_DB_PASS}"
+    healthcheck:
+      test: ["CMD-SHELL", '/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$$MSSQL_SA_PASSWORD" -Q ''SELECT 1''']
+      interval: 5s
+      timeout: 5s
+      retries: 10
     networks:
       bds-local-dev-net:
         aliases:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bulk-data-service"
-version = "1.4.2"
+version = "1.4.3"
 requires-python = ">= 3.12.6"
 readme = "README.md"
 dependencies = [

--- a/tests-local-environment/docker-compose.yml
+++ b/tests-local-environment/docker-compose.yml
@@ -78,7 +78,8 @@ services:
       ACCEPT_EULA: "Y"
       SQL_WAIT_INTERVAL: 3
     depends_on:
-      - bds-test-env-mq-db
+      bds-test-env-mq-db:
+        condition: service_healthy
     networks:
       bds-local-test-net:
         aliases:
@@ -91,6 +92,11 @@ services:
     environment:
       ACCEPT_EULA: "Y"
       MSSQL_SA_PASSWORD: "${AZURE_SERVICE_BUS_DB_PASS}"
+    healthcheck:
+      test: ["CMD-SHELL", '/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$$MSSQL_SA_PASSWORD" -Q ''SELECT 1''']
+      interval: 5s
+      timeout: 5s
+      retries: 10
     networks:
       bds-local-test-net:
         aliases:

--- a/web/index-template.html
+++ b/web/index-template.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <title>IATI Bulk Data Service</title>
-  <link href="https://cdn.jsdelivr.net/npm/iati-design-system@3.14.0/dist/css/iati.min.css" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/iati-design-system@4.6.0/dist/css/iati.min.css" rel="stylesheet" />
 </head>
 
 <body class="iati-design-system--enabled">
@@ -32,7 +32,6 @@
 
       <div class="iati-header__section iati-header__section--last iati-brand-background">
         <div class="iati-header__container iati-brand-background__content">
-
           <div class="iati-header__actions">
             <div class="iati-country-switcher">
               <label for="iati-country-switcher" class="iati-country-switcher__label">Choose your language</label>
@@ -40,11 +39,15 @@
                 <option>English</option>
               </select>
             </div>
+            <button class="iati-button iati-button--light hide--mobile-nav" onclick="window.location.assign('https://docs.unified-platform.iatistandard.org/en/latest/bulk-data-service/')">
+              <span>Help Docs</span>
+              <i class="iati-icon iati-icon--info"></i>
+            </button>
           </div>
 
           <div class="iati-header-title">
             <p class="iati-header-title__eyebrow">IATI Tools</p>
-            <p class="iati-header-title__heading">IATI Bulk Data Download</p>
+            <p class="iati-header-title__heading">IATI Bulk Data Service</p>
           </div>
 
         </div>
@@ -54,6 +57,12 @@
   </div>
 
   <main class="iati-main">
+    <p>
+      You can download IATI data from this service, in the packages below. The
+      first three packages contain indices of the data, and the last package is a
+      ZIP file containing all the data files.
+    </p>
+
     <h1>Links</h1>
     <p><a href="/datasets-minimal">IATI Dataset Index - Minimal (JSON)</a></p>
     <p><a href="/datasets-full">IATI Dataset Index - Full (JSON)</a></p>


### PR DESCRIPTION
This PR will:
* Update the page to refer to the BDS as the BDS and not Bulk Data Download
* Add a Help Docs button
* Add a line of explanatory text to what the links are.
* Improves the `docker compose` setup slightly with a missing healthcheck.