### PR TITLE
Revert fixed IP

### DIFF
--- a/.github/workflows/build-and-deploy-job.yml
+++ b/.github/workflows/build-and-deploy-job.yml
@@ -143,8 +143,6 @@ jobs:
             az -v
             az container create --debug \
             --resource-group "${{ env.RESOURCE_GROUP_BASE_NAME }}-${{ env.TARGET_ENVIRONMENT }}" \
-            --vnet "/subscriptions/${{ env.AZURE_SUBSCRIPTION_ID }}/resourceGroups/rg-${{ env.APP_NAME }}-vnets/providers/Microsoft.Network/virtualNetworks/${{ env.APP_NAME }}-${{ env.TARGET_ENVIRONMENT }}-vnet" \
-            --subnet "/subscriptions/${{ env.AZURE_SUBSCRIPTION_ID }}/resourceGroups/rg-${{ env.APP_NAME }}-vnets/providers/Microsoft.Network/virtualNetworks/${{ env.APP_NAME }}-${{ env.TARGET_ENVIRONMENT }}-vnet/subnets/${{ env.APP_NAME }}-${{ env.TARGET_ENVIRONMENT }}-subnet" \
             --file ./azure-deployment/azure-resource-manager-deployment-manifest.yml
 
       - name: 'Re-generate the website links'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Removed
 
+## [1.4.8] - 2026-05-18
+
+### Removed
+
+ - Fixed IP deployment
+
 ## [1.4.7] - 2026-05-11
 
 ### Added

--- a/azure-deployment/azure-resource-manager-deployment-template.yml
+++ b/azure-deployment/azure-resource-manager-deployment-template.yml
@@ -105,9 +105,8 @@ properties: # Properties of container group
           requests:
             cpu: 1.0
             memoryInGB: 0.5
-  subnetIds:
-    - id: "/subscriptions/#AZURE_SUBSCRIPTION_ID#/resourceGroups/rg-#APP_NAME#-vnets/providers/Microsoft.Network/virtualNetworks/#APP_NAME#-#TARGET_ENVIRONMENT#-vnet/subnets/#APP_NAME#-#TARGET_ENVIRONMENT#-subnet"
   ipAddress:
-    type: "private"
+    type: "public"
+    dnsNameLabel: "#APP_NAME#-#TARGET_ENVIRONMENT#"
     ports:
       - port: 9158

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bulk-data-service"
-version = "1.4.7"
+version = "1.4.8"
 requires-python = ">= 3.12.6"
 readme = "README.md"
 dependencies = [


### PR DESCRIPTION
PR https://github.com/IATI/bulk-data-service/pull/142 made a change allowing the BDS to be deployed to fixed, public-facing IPs, but due to the NAT gateway use, these are expensive and result in significant slow down due to how the BDS works internally. 

This PR reverts that change, deploying once more to a public, changeable IP.