### PR TITLE
Update code list for `licence_id` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Removed
 
+## [1.4.11] - 2026-07-29
+
+### Changed
+
+ - Updated licence codelist list with new licence code 'other'.
+
 ## [1.4.10] - 2026-07-27
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bulk-data-service"
-version = "1.4.10"
+version = "1.4.11"
 requires-python = ">= 3.12.6"
 readme = "README.md"
 dependencies = [

--- a/src/bulk_data_service/data_validation_values.py
+++ b/src/bulk_data_service/data_validation_values.py
@@ -255,6 +255,7 @@ COUNTRY_CODELIST = [
 
 LICENCE_LIST = [
     "",
+    "other",
     "notspecified",
     "odc-pddl",
     "odc-odbl",


### PR DESCRIPTION
This PR makes a single line change to add the new `licence_id` value of `other`, which has been added as a catch all in case none of the licences in the newly restricted list applies.

NOTE: this PR has been diffed against the `sk-frontend-improvements` branch; that branch should be merged first, then this one.