### PR TITLE
Create a metadata JSON file for info about indices for use by landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Removed
 
+## [1.4.12] - 2026-08-03
+
+### Changed
+
+ - Added a small meta JSON file for use by the landing page so that it can show
+   the last updated timestamps without needing to access the full indices.
+
 ## [1.4.11] - 2026-07-29
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bulk-data-service"
-version = "1.4.11"
+version = "1.4.12"
 requires-python = ">= 3.12.6"
 readme = "README.md"
 dependencies = [

--- a/src/bulk_data_service/dataset_indexing.py
+++ b/src/bulk_data_service/dataset_indexing.py
@@ -34,6 +34,10 @@ def create_and_upload_indices(
 
     upload_index_json_to_azure(context, get_reporting_org_index_name(context), reporting_org_index)
 
+    upload_index_json_to_azure(
+        context, get_indices_meta_json_name(context), create_meta_json(context, index_creation_time)
+    )
+
     context.logger.info("Creation of indices finished")
 
 
@@ -74,6 +78,37 @@ def create_reporting_org_index_json(
     index["reporting_orgs"] = get_reporting_orgs_for_datasets(context, datasets_in_bds, reporting_orgs_in_bds)
 
     return json.dumps(index, default=str, sort_keys=True, indent=True)
+
+
+def create_meta_json(
+    context: BDSContext,
+    created_time: datetime,
+) -> str:
+    """Generate meta data for the indices (currently just the timestamps)
+
+    Args:
+        context (BDSContext): App context
+        created_time (datetime): Time the indices were created
+
+    Returns:
+        str: JSON of indices meta data
+    """
+
+    index_created_entries = create_index_created_entries(created_time)
+
+    return json.dumps(
+        {
+            "meta": {
+                "datasets_minimal": index_created_entries,
+                "datasets_full": index_created_entries,
+                "reporting_orgs": index_created_entries,
+                "zip": index_created_entries,
+            }
+        },
+        default=str,
+        sort_keys=True,
+        indent=True,
+    )
 
 
 def create_index_created_entries(created_time: datetime) -> dict[str, Any]:
@@ -117,3 +152,7 @@ def get_dataset_index_name(context: BDSContext, index_type: str) -> str:
 
 def get_reporting_org_index_name(context: BDSContext) -> str:
     return "reporting-orgs"
+
+
+def get_indices_meta_json_name(context: BDSContext) -> str:
+    return "indices-meta"

--- a/web/index-template.html
+++ b/web/index-template.html
@@ -98,33 +98,40 @@
         </tr>
         <tr>
           <td><a href="{{WEB_BASE_URL}}/iati-data.zip">IATI Bulk Data Download ZIP</a></td>
-          <td></td>
+          <td id="zipLastUpdated"></td>
         </tr>
       </tbody>
     </table>
 
     <script>
       (function () {
-        var files = [
-          { elementId: 'datasetsMinimalLastUpdated', label: 'Last updated: ', url: '/datasets-minimal' },
-          { elementId: 'datasetsFullLastUpdated', label: 'Last updated: ', url: '/datasets-full' },
-          { elementId: 'reportingOrgsLastUpdated', label: 'Last updated: ', url: '/reporting-orgs' }
+        var cells = [
+          { elementId: 'datasetsMinimalLastUpdated', metaKey: 'datasets_minimal' },
+          { elementId: 'datasetsFullLastUpdated', metaKey: 'datasets_full' },
+          { elementId: 'reportingOrgsLastUpdated', metaKey: 'reporting_orgs' },
+          { elementId: 'zipLastUpdated', metaKey: 'zip' }
         ];
-        files.forEach(function (f) {
-          var el = document.getElementById(f.elementId);
-          fetch(f.url)
-            .then(function (r) {
-              if (!r.ok) { throw new Error(r.status + ' ' + r.statusText); }
-              return r.json();
-            })
-            .then(function (data) {
-              if (el) { el.textContent = f.label + (data.index_created || 'Unknown'); }
-            })
-            .catch(function (err) {
-              if (el) { el.textContent = f.label + 'Unavailable'; }
-              console.warn('Could not fetch ' + f.url + ': ' + err.message);
+        var label = 'Last updated: ';
+        var setText = function (el, text) {
+          if (el) { el.textContent = label + text; }
+        };
+        fetch('/indices-meta')
+          .then(function (r) {
+            if (!r.ok) { throw new Error(r.status + ' ' + r.statusText); }
+            return r.json();
+          })
+          .then(function (data) {
+            cells.forEach(function (c) {
+              var entry = data.meta && data.meta[c.metaKey];
+              setText(document.getElementById(c.elementId), (entry && entry.index_created) || 'Unknown');
             });
-        });
+          })
+          .catch(function (err) {
+            cells.forEach(function (c) {
+              setText(document.getElementById(c.elementId), 'Unavailable');
+            });
+            console.warn('Could not fetch /indices-meta: ' + err.message);
+          });
       })();
     </script>
   </main>


### PR DESCRIPTION
This PR modifies the Bulk Data Service to create and upload to Azure a small metadata file containing the last updated timestamps for each of the indices. It is intended for internal use by the landing page, so that the landing page can show the last update timestamps without having to fetch all the indices itself.

It also prints out the last updated time next to the ZIP file, too, to help avoid confusing over why that file doesn't have a timestamp.

(I decided to speed up the landing page this way rather than using `HEAD` requests because the updated header returned as part of the `HEAD` request won't match the time in the index file, and that would be confusing the end users).