### PR TITLE
feat: logs non-secret env variables on startup

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -3,40 +3,57 @@ from pathlib import Path
 
 import toml
 
-_config_variables = [
-    "DATA_REGISTRATION",
-    "DATA_REGISTRY_BASE_URL",
-    "DATA_REGISTRY_PUBLISHER_PLAIN_LIST_URL",
-    "DATA_REGISTRY_PUBLISHER_METADATA_URL",
-    "DATA_REGISTRY_PUBLISHER_METADATA_BATCH_SIZE",
-    "DATA_REGISTRY_SUITECRM_API_URL",
-    "DATA_REGISTRY_SUITECRM_CLIENT_ID",
-    "DATA_REGISTRY_SUITECRM_CLIENT_SECRET",
-    "DATA_REGISTRY_SUITECRM_SECURE",
-    "WEB_BASE_URL",
-    "NUMBER_DOWNLOADER_THREADS",
-    "FORCE_REDOWNLOAD_AFTER_HOURS",
-    "REDOWNLOAD_FROM_NON_HEAD_SERVERS_AFTER_HOURS",
-    "REMOVE_LAST_GOOD_DOWNLOAD_AFTER_FAILING_HOURS",
-    "ZIP_WORKING_DIR",
-    "DB_NAME",
-    "DB_USER",
-    "DB_PASS",
-    "DB_HOST",
-    "DB_PORT",
-    "DB_SSL_MODE",
-    "DB_CONNECTION_TIMEOUT",
-    "AZURE_STORAGE_CONNECTION_STRING",
-    "AZURE_STORAGE_BLOB_CONTAINER_NAME",
-    "CHECKER_LOOP_WAIT_MINS",
-    "AZURE_SERVICE_BUS_CONNECTION_STRING",
-    "AZURE_SERVICE_BUS_REGISTRY_TOPIC_NAME",
-    "AZURE_SERVICE_BUS_REGISTRY_SUB_NAME",
-    "AZURE_SERVICE_BUS_WAIT_TIME",
-    "AZURE_SERVICE_BUS_DATASET_CHECK_RESULTS_TOPIC_NAME",
-    "SEND_DATASET_CHECK_RESULT_MESSAGES",
-    "DATASET_HEAD_TIMEOUT",
-    "DATASET_GET_TIMEOUT",
+# Flags for whether a configuration variable's value may be written to the logs
+# when the app starts. Anything marked SECRET is not logged at all, not even to
+# indicate whether it is set.
+LOGGABLE = True
+SECRET = False
+
+_config_variables = {
+    "DATA_REGISTRATION": LOGGABLE,
+    "DATA_REGISTRY_BASE_URL": LOGGABLE,
+    "DATA_REGISTRY_PUBLISHER_PLAIN_LIST_URL": LOGGABLE,
+    "DATA_REGISTRY_PUBLISHER_METADATA_URL": LOGGABLE,
+    "DATA_REGISTRY_PUBLISHER_METADATA_BATCH_SIZE": LOGGABLE,
+    "DATA_REGISTRY_SUITECRM_API_URL": LOGGABLE,
+    "DATA_REGISTRY_SUITECRM_CLIENT_ID": SECRET,
+    "DATA_REGISTRY_SUITECRM_CLIENT_SECRET": SECRET,
+    "DATA_REGISTRY_SUITECRM_SECURE": LOGGABLE,
+    "WEB_BASE_URL": LOGGABLE,
+    "NUMBER_DOWNLOADER_THREADS": LOGGABLE,
+    "FORCE_REDOWNLOAD_AFTER_HOURS": LOGGABLE,
+    "REDOWNLOAD_FROM_NON_HEAD_SERVERS_AFTER_HOURS": LOGGABLE,
+    "REMOVE_LAST_GOOD_DOWNLOAD_AFTER_FAILING_HOURS": LOGGABLE,
+    "ZIP_WORKING_DIR": LOGGABLE,
+    "DB_NAME": SECRET,
+    "DB_USER": SECRET,
+    "DB_PASS": SECRET,
+    "DB_HOST": SECRET,
+    "DB_PORT": SECRET,
+    "DB_SSL_MODE": SECRET,
+    "DB_CONNECTION_TIMEOUT": LOGGABLE,
+    "AZURE_STORAGE_CONNECTION_STRING": SECRET,
+    "AZURE_STORAGE_BLOB_CONTAINER_NAME": LOGGABLE,
+    "CHECKER_LOOP_WAIT_MINS": LOGGABLE,
+    "AZURE_SERVICE_BUS_CONNECTION_STRING": SECRET,
+    "AZURE_SERVICE_BUS_REGISTRY_TOPIC_NAME": LOGGABLE,
+    "AZURE_SERVICE_BUS_REGISTRY_SUB_NAME": LOGGABLE,
+    "AZURE_SERVICE_BUS_WAIT_TIME": LOGGABLE,
+    "AZURE_SERVICE_BUS_DATASET_CHECK_RESULTS_TOPIC_NAME": LOGGABLE,
+    "SEND_DATASET_CHECK_RESULT_MESSAGES": LOGGABLE,
+    "DATASET_HEAD_TIMEOUT": LOGGABLE,
+    "DATASET_GET_TIMEOUT": LOGGABLE,
+}
+
+# Settings which come from the command line rather than from the environment.
+# These cannot be added to `_config_variables` because `get_basic_config` would
+# then read them from the environment and overwrite the values from the command
+# line with empty strings.
+_loggable_runtime_settings = [
+    "single_run",
+    "run_for_n_datasets",
+    "run_for_single_reporting_org",
+    "skip_safety",
 ]
 
 
@@ -48,6 +65,16 @@ def get_basic_config() -> dict:
     config["BULK_DATA_SERVICE_VERSION"] = get_app_version()
 
     return config
+
+
+def get_config_for_logging(config: dict) -> list[str]:
+    """Returns the configuration as a list of 'NAME=value' strings, containing
+    only the variables which are marked as LOGGABLE, plus the settings which
+    come from the command line."""
+
+    loggable_variables = [name for name, loggable in _config_variables.items() if loggable]
+
+    return ["{}={}".format(name, config.get(name)) for name in loggable_variables + _loggable_runtime_settings]
 
 
 def get_app_version() -> str:

--- a/src/iati_bulk_data_service.py
+++ b/src/iati_bulk_data_service.py
@@ -4,7 +4,7 @@ from bulk_data_service.checker import checker
 from bulk_data_service.registry_changes_processor import registry_changes_processor_start
 from bulk_data_service.zipper import zipper
 from config.bds_context import BDSContext
-from config.config import get_basic_config
+from config.config import get_basic_config, get_config_for_logging
 from config.initialisation import misc_global_initialisation
 from config.service_factory import ServiceFactory
 from utilities.azure import create_azure_blob_containers
@@ -24,9 +24,17 @@ def main(args: argparse.Namespace):
         "skip_safety": args.skip_safety,
     }
 
-    context = BDSContext(config, initialise_logging(config), ServiceFactory(config))
+    logger = initialise_logging(config)
 
-    context.logger.info("Bulk Data Service {} initialising...".format(context["BULK_DATA_SERVICE_VERSION"]))
+    logger.info("Bulk Data Service {} initialising...".format(config["BULK_DATA_SERVICE_VERSION"]))
+
+    # logged before the context is created because creating the context coerces
+    # some of the config values, and so can fail on a bad value: we want the
+    # config to be in the log before that can happen
+    for config_line in get_config_for_logging(config):
+        logger.info("Config: {}".format(config_line))
+
+    context = BDSContext(config, logger, ServiceFactory(config))
 
     apply_db_migrations(context)
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -3,7 +3,12 @@ from unittest import mock
 from dotenv import load_dotenv
 
 from config.bds_context import BDSContext
-from config.config import get_basic_config
+from config.config import (
+    _config_variables,
+    _loggable_runtime_settings,
+    get_basic_config,
+    get_config_for_logging,
+)
 
 
 def test_config_blob_storage_base_url_has_no_trailing_slash_1():
@@ -34,3 +39,53 @@ def test_config_dataset_timeouts_loaded():
     assert context.DATASET_GET_TIMEOUT == 22
 
     assert context.DATASET_HEAD_TIMEOUT == 7
+
+
+def get_config_lines_for_env_file_2() -> list[str]:
+    load_dotenv("tests/artifacts/config-files/env-file-2", override=True)
+
+    config = get_basic_config() | {
+        "single_run": True,
+        "run_for_n_datasets": 3,
+        "run_for_single_reporting_org": None,
+        "skip_safety": False,
+    }
+
+    return get_config_for_logging(config)
+
+
+def test_config_for_logging_contains_exactly_the_loggable_variables():
+
+    names_logged = [line.split("=", 1)[0] for line in get_config_lines_for_env_file_2()]
+
+    expected_names = [name for name, loggable in _config_variables.items() if loggable] + _loggable_runtime_settings
+
+    assert names_logged == expected_names
+
+
+def test_config_for_logging_omits_secret_variables():
+
+    config_output = "\n".join(get_config_lines_for_env_file_2())
+
+    secret_names = [name for name, loggable in _config_variables.items() if not loggable]
+
+    for secret_name in secret_names:
+        assert secret_name not in config_output
+
+
+def test_config_for_logging_does_not_contain_secret_values():
+
+    config_output = "\n".join(get_config_lines_for_env_file_2())
+
+    # fragments of the secret values which are set in the env file used above
+    for secret_value_fragment in ["AccountKey", "SharedAccessKey", "Eby8vdM02xNOcqFlqUwJPLl"]:
+        assert secret_value_fragment not in config_output
+
+
+def test_get_basic_config_reads_every_config_variable():
+    load_dotenv("tests/artifacts/config-files/env-file-2", override=True)
+
+    config = get_basic_config()
+
+    for name in _config_variables:
+        assert name in config


### PR DESCRIPTION
The configuration is now written to the log when the service is run. Each configuration variable in `config.py` carries a flag marking whether its value may be logged: so a variable added in future is private unless it is explicitly marked `LOGGABLE`. 
The settings which come from the command line are logged too.

Current flags are my best guess. 