### PR TITLE
fix: make Azure retry defaults explicit

### DIFF
--- a/src/bulk_data_service/dataset_updater.py
+++ b/src/bulk_data_service/dataset_updater.py
@@ -67,7 +67,14 @@ def add_or_update_dataset_batch(
 
     db_conn = get_db_connection(context)
 
-    az_blob_service = BlobServiceClient.from_connection_string(context["AZURE_STORAGE_CONNECTION_STRING"])
+    az_blob_service = BlobServiceClient.from_connection_string(
+        context["AZURE_STORAGE_CONNECTION_STRING"],
+        retry_total=3,
+        retry_connect=3,
+        retry_read=3,
+        retry_status=3,
+        retry_to_secondary=False,
+    )
 
     session = get_requests_session(context)
 

--- a/tests/unit/test_dataset_updater.py
+++ b/tests/unit/test_dataset_updater.py
@@ -1,0 +1,24 @@
+from unittest import mock
+
+from bulk_data_service.dataset_updater import add_or_update_dataset_batch
+
+
+@mock.patch("bulk_data_service.dataset_updater.get_requests_session")
+@mock.patch("bulk_data_service.dataset_updater.get_db_connection")
+@mock.patch("bulk_data_service.dataset_updater.BlobServiceClient.from_connection_string")
+def test_blob_service_client_uses_explicit_default_retries(from_connection_string, get_db_connection, get_session):
+    context = {"AZURE_STORAGE_CONNECTION_STRING": "UseDevelopmentStorage=true"}
+
+    add_or_update_dataset_batch(context, {}, {})
+
+    from_connection_string.assert_called_once_with(
+        "UseDevelopmentStorage=true",
+        retry_total=3,
+        retry_connect=3,
+        retry_read=3,
+        retry_status=3,
+        retry_to_secondary=False,
+    )
+    from_connection_string.return_value.close.assert_called_once_with()
+    get_db_connection.return_value.close.assert_called_once_with()
+    get_session.return_value.close.assert_called_once_with()


### PR DESCRIPTION
## Summary

Make the Azure Blob client retry configuration explicit where dataset batches create the client. The values match the pinned Azure SDK's existing `ExponentialRetry` behavior, so this documents the current policy without adding another retry loop or changing runtime behavior.

The regression test verifies all retry options passed to `BlobServiceClient.from_connection_string` and the existing resource cleanup.

## Verification

- pinned Azure SDK runtime comparison: implicit and explicit policies both resolve to total/connect/read/status `3` and secondary retry `False`
- `pytest -q tests/unit` (101 passed)
- `isort --check-only .`
- `black --check .`
- `mypy src/bulk_data_service/dataset_updater.py`
- `flake8 tests/unit/test_dataset_updater.py`
- `git diff --check`

The full integration suite was not run locally because the configured Docker/Colima daemon is unavailable. GitHub Actions will run the repository's Docker-backed test workflow. Flake8 on `dataset_updater.py` retains the same pre-existing `C901` warning present on `develop`.

Closes #85
